### PR TITLE
Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.5
+- fix membership starting after it ended
+- fix import for AS being a member of an IX for multiple prefixes
+- ensure we don't re-add a membership where not appropriate
+
+## 0.4
+- move membership details to separate model so we can track changes over time
+
+## 0.3
+- add per-ixp and per-country stats over time
+
+## 0.2
+- add ability to backfill data from CAIDA archive
+
+## 0.1
+- import ASNs, IXPs and members

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ixp-tracker"
-version = "0.4"
+version = "0.5"
 description = "Library to retrieve and manipulate data about IXPs"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_members_import.py
+++ b/tests/test_members_import.py
@@ -4,7 +4,7 @@ import dateutil.parser
 import pytest
 
 from ixp_tracker import importers
-from ixp_tracker.importers import ASNGeoLookup
+from ixp_tracker.importers import ASNGeoLookup, dedupe_member_data
 from ixp_tracker.models import ASN, IXP, IXPMember, IXPMembershipRecord
 
 pytestmark = pytest.mark.django_db
@@ -17,6 +17,33 @@ dummy_member_data = {
     "is_rs_peer": True,
     "speed": 10000,
 }
+
+multiple_member_data = [
+    {
+        "asn": 56789,
+        "ix_id": 5,
+        "created": "2019-08-24T14:15:22Z",
+        "updated": "2019-08-24T14:15:22Z",
+        "is_rs_peer": False,
+        "speed": 10000,
+    },
+    {
+        "asn": 56789,
+        "ix_id": 5,
+        "created": "2018-08-24T14:15:22Z",
+        "updated": "2018-08-24T14:15:22Z",
+        "is_rs_peer": True,
+        "speed": 3000,
+    },
+    {
+        "asn": 56789,
+        "ix_id": 5,
+        "created": "2020-08-24T14:15:22Z",
+        "updated": "2020-08-24T14:15:22Z",
+        "is_rs_peer": False,
+        "speed": 4000,
+    }
+]
 
 date_now = datetime.utcnow().replace(tzinfo=timezone.utc)
 
@@ -235,6 +262,108 @@ def test_marks_member_as_left_if_asn_is_not_assigned():
 
     current_membership = IXPMembershipRecord.objects.filter(member=member)
     assert current_membership.first().end_date.strftime("%Y-%m-%d") == last_day_of_last_month.strftime("%Y-%m-%d")
+
+
+def test_does_not_mark_as_left_before_joining_date():
+    asn = create_asn_fixture(dummy_member_data["asn"], "ZZ")
+    ixp = create_ixp_fixture(dummy_member_data["ix_id"])
+    first_day_of_month = datetime.utcnow().replace(day=1)
+    member = IXPMember(
+        ixp=ixp,
+        asn=asn,
+        last_updated=dummy_member_data["updated"],
+        last_active=datetime.utcnow()
+    )
+    member.save()
+    membership = IXPMembershipRecord(
+        member=member,
+        start_date=first_day_of_month.date(),
+        is_rs_peer=False,
+        speed=500
+    )
+    membership.save()
+
+    processor = importers.process_member_data(date_now, TestLookup("available"))
+    processor([])
+
+    current_membership = IXPMembershipRecord.objects.filter(member=member)
+    assert current_membership.first().end_date.strftime("%Y-%m-%d") == first_day_of_month.strftime("%Y-%m-%d")
+
+
+def test_ensure_multiple_member_entries_does_not_trigger_multiple_new_memberships():
+    asn = create_asn_fixture(dummy_member_data["asn"])
+    ixp = create_ixp_fixture(dummy_member_data["ix_id"])
+    member = IXPMember(
+        ixp=ixp,
+        asn=asn,
+        last_updated=dummy_member_data["updated"],
+        last_active=datetime(year=2023, month=7, day=13)
+    )
+    member.save()
+    # As we always create a new membership record if the most recent one has ended, for multiple ASN-IX combos this
+    # could result in multiple new memberships being created
+    membership = IXPMembershipRecord(
+        member=member,
+        start_date=datetime(year=2023, month=1, day=13),
+        is_rs_peer=False,
+        speed=500,
+        end_date=datetime(year=2023, month=7, day=13)
+    )
+    membership.save()
+
+    processor = importers.process_member_data(date_now, TestLookup())
+    processor([dummy_member_data, dummy_member_data])
+
+    memberships = IXPMembershipRecord.objects.filter(member=member)
+    assert len(memberships) == 2
+
+
+def test_do_not_add_new_membership_for_same_created_date():
+    asn = create_asn_fixture(dummy_member_data["asn"])
+    ixp = create_ixp_fixture(dummy_member_data["ix_id"])
+    member = IXPMember(
+        ixp=ixp,
+        asn=asn,
+        last_updated=dummy_member_data["updated"],
+        last_active=datetime(year=2023, month=7, day=13)
+    )
+    member.save()
+    # As we always create a new membership record if the most recent one has ended, for multiple ASN-IX combos this
+    # could result in multiple new memberships being created
+    membership = IXPMembershipRecord(
+        member=member,
+        start_date=dateutil.parser.isoparse(dummy_member_data["created"]).date(),
+        is_rs_peer=False,
+        speed=500,
+        end_date=datetime(year=2023, month=7, day=13)
+    )
+    membership.save()
+
+    processor = importers.process_member_data(date_now, TestLookup())
+    processor([dummy_member_data])
+
+    memberships = IXPMembershipRecord.objects.filter(member=member)
+    assert len(memberships) == 1
+
+
+def test_dedupes_member_data_before_processing():
+    deduped_data = dedupe_member_data(multiple_member_data)
+
+    assert len(deduped_data) == 1
+
+
+def test_set_rs_peer_to_true_if_any_member_is_set_to_true():
+    deduped_data = dedupe_member_data(multiple_member_data)
+
+    deduped_member = deduped_data[0]
+    assert deduped_member["is_rs_peer"]
+
+
+def test_speed_for_deduped_members_is_sum_of_all_speeds():
+    deduped_data = dedupe_member_data(multiple_member_data)
+
+    deduped_member = deduped_data[0]
+    assert deduped_member["speed"] == 17000
 
 
 def create_asn_fixture(as_number: int, country: str = "CH"):


### PR DESCRIPTION
Tested locally and both these fixes seem to work. After importing 4 months worth of data, there are no memberships with start dates after their end date. There is only one member with more than 2 membership records and that looks "genuine"
id,start_date,is_rs_peer,speed,end_date
22601,2018-12-13,true,1000,2018-12-31
23080,2019-01-18,true,1000,2019-01-31
23546,2019-02-21,true,1000,2019-02-28
