### PR TITLE
Ensure we extend memberships where necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6
+- extend a membership if created date for imported record is before end date of previous record
+
 ## 0.5
 - fix membership starting after it ended
 - fix import for AS being a member of an IX for multiple prefixes

--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -212,15 +212,17 @@ def process_member_data(processing_date: datetime, geo_lookup: ASNGeoLookup):
                         # Avoid re-adding a member for the same start_date
                         continue
                     if membership.end_date > created_date:
-                        logger.warning("We might have overlapping memberships", extra=log_data)
-                    # Most recent membership has ended so create a new membership record
-                    membership = IXPMembershipRecord(
-                        member=member,
-                        start_date=created_date,
-                        is_rs_peer=member_data["is_rs_peer"],
-                        speed=member_data["speed"]
-                    )
-                    logger.debug("Created new membership as previous one ended", extra=log_data)
+                        logger.debug("Extending membership", extra=log_data)
+                        membership.end_date = None
+                    else:
+                        # Most recent membership has ended so create a new membership record
+                        membership = IXPMembershipRecord(
+                            member=member,
+                            start_date=created_date,
+                            is_rs_peer=member_data["is_rs_peer"],
+                            speed=member_data["speed"]
+                        )
+                        logger.debug("Created new membership as previous one ended", extra=log_data)
                 membership.save()
 
             logger.debug("Imported IXP member record", extra=log_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ixp-tracker"
-version = "0.5"
+version = "0.6"
 description = "Library to retrieve and manipulate data about IXPs"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Pending discussions internally, I've decided to fix this as the original case we saw looks like an overlap.
AS668 for IX 4, in the data for 2021-06-01:
```
{
  "ix_id": 4,
  "asn": 668,
  "updated": "2016-03-14T20:45:05Z",
  "created": "2014-01-02T00:00:00Z",
  "ipaddr4": "206.223.123.159",
  "ipaddr6": "2001:504:0:3::668:1",
}
```
and for the most recent data
```
{
  "ix_id": 4,
  "asn": 668,
  "updated": "2023-02-16T12:12:33Z",
  "created": "2021-05-12T05:19:09Z",
  "ipaddr4": "206.223.123.18",
  "ipaddr6": "2001:504:0:3::668:2",
}
```

Note it looks like this AS connected to the IX using a different prefix but was probably continuously a member over the whole period.