### PR TITLE
Fix IXP counts in per-country stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10
+- fixed IXP count in per-country stats
+
 ## 0.9
 - add IXP count to per-country stats (will default to zero for any existing stats so those will need to be re-generated)
 

--- a/ixp_tracker/stats.py
+++ b/ixp_tracker/stats.py
@@ -22,7 +22,7 @@ def generate_stats(geo_lookup: ASNGeoLookup, stats_date: datetime = None):
     stats_date = stats_date.replace(day=1)
     # Give IXPs a month's grace to be considered "active" for the purpose of the stats as "last_updated" is only updated when the status is toggled
     ixp_considered_active = (stats_date - timedelta(days=1)).replace(day=1, hour=0, minute=0, second=0)
-    ixps = IXP.objects.filter(created__lte=stats_date, last_updated__gte=ixp_considered_active).all()
+    ixps = IXP.objects.filter(created__lte=stats_date, last_active__gte=ixp_considered_active).all()
     all_members = (IXPMember.objects
                    .filter(
                         Q(memberships__start_date__lte=stats_date) &

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ixp-tracker"
-version = "0.9"
+version = "0.10"
 description = "Library to retrieve and manipulate data about IXPs"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,8 +20,8 @@ def create_asn_fixture(as_number: int, country: str = "CH"):
     return asn
 
 
-def create_ixp_fixture(peering_db_id: int, country = "MM", last_updated: datetime = None):
-    last_updated = last_updated or datetime.now(timezone.utc)
+def create_ixp_fixture(peering_db_id: int, country = "MM", last_active: datetime = None):
+    last_active = last_active or datetime.now(timezone.utc)
     ixp = IXP(
         name="Old name",
         long_name="Network Name",
@@ -31,8 +31,8 @@ def create_ixp_fixture(peering_db_id: int, country = "MM", last_updated: datetim
         peeringdb_id=peering_db_id,
         country_code=country,
         created=datetime(year=2020,month=10,day=1, tzinfo=timezone.utc),
-        last_updated=last_updated,
-        last_active=datetime(year=2024, month=4, day=1, tzinfo=timezone.utc)
+        last_updated=datetime(year=2024, month=4, day=1, tzinfo=timezone.utc),
+        last_active=last_active
     )
     ixp.save()
     return ixp


### PR DESCRIPTION
After running some data, it turns out `last_active` is a better date to use for the IXP counts (rather than `last_updated` as that can be months ago if nothing has changed in the data for that IXP).