### PR TITLE
Use active member counts to count IXPs rather than IXP itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.11
+- ensured inactive IXPs are not counted in per-country stats
+
 ## 0.10
 - fixed IXP count in per-country stats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ixp-tracker"
-version = "0.10"
+version = "0.11"
 description = "Library to retrieve and manipulate data about IXPs"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_country_stats.py
+++ b/tests/test_country_stats.py
@@ -55,19 +55,23 @@ def test_generates_stats():
 
 
 def test_generates_ixp_counts():
-    # currently_active
-    create_ixp_fixture(123, "CH", datetime.now(timezone.utc))
-    last_month = (datetime.now(timezone.utc).replace(day=1) - timedelta(days=1)).replace(day=1)
-    # active_last_month
-    create_ixp_fixture(124, "CH", last_month)
-    before_last_month = last_month - timedelta(days=1)
-    # not_active_recently
-    create_ixp_fixture(125, "CH", before_last_month)
+    stats_date = (datetime.now(timezone.utc) - timedelta(weeks=16)).replace(day=1)
+    one_month_before = (stats_date - timedelta(days=1)).replace(day=1)
+    one_month_after = (stats_date - timedelta(days=35)).replace(day=1)
+    # currently_active member
+    active = create_ixp_fixture(123, "CH")
+    create_member_fixture(active, 12345, 500, member_since=one_month_before, date_left=one_month_after)
+    # member active in the past
+    member_in_past = create_ixp_fixture(124, "CH")
+    create_member_fixture(member_in_past, 12345, 500, member_since=one_month_before, date_left=one_month_before)
+    # member not yet active (as we are generating historical stats there could be members in the future)
+    mmeber_in_future = create_ixp_fixture(125, "CH")
+    create_member_fixture(mmeber_in_future, 12345, 500, member_since=one_month_after, date_left=None)
 
     generate_stats(TestLookup())
 
     stats = StatsPerCountry.objects.filter(country_code="CH").first()
-    assert stats.ixp_count == 2
+    assert stats.ixp_count == 1
 
 
 def test_handles_invalid_country():


### PR DESCRIPTION
The active flag is the *current* status of an IXP but we need to detect the historical status, which is best derived from the membership data