### PR TITLE
Use 3 members as definition of active IXP rather than just 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.15
+- change definition of active status for an IXP from at least 1 member to at least 3 members
+
 ## 0.14
 - add local_routed_asns_members_rate to per-IXP stats
 - add routed_asns_ixp_member_rate and routed_asn_count to per-country stats

--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -283,14 +283,14 @@ def toggle_ixp_active_status(processing_date: datetime):
         # Note that `last_active` is the date we last saw the IXP in the source data and is used to track deletions
         # We update `last_updated` here when we toggle the active status as we use that to signify our IXP record has been changed
         # even though usually `last_updated` is taken from the source data field of the same name
-        if ixp.active_status and len(active_members) == 0:
-            ixp.active_status = False
+        new_active_status = is_ixp_active(active_members)
+        if ixp.active_status != new_active_status:
+            ixp.active_status = new_active_status
             ixp.last_updated = processing_date
             ixp.save()
-            logger.debug("Marked IXP as inactive", extra={"ixp": ixp.peeringdb_id})
-        elif not ixp.active_status and len(active_members) > 0:
-            ixp.active_status = True
-            ixp.last_updated = processing_date
-            ixp.save()
-            logger.debug("Marked IXP as active", extra={"ixp": ixp.peeringdb_id})
+            logger.debug("Toggle IXP active status", extra={"ixp": ixp.peeringdb_id})
     return
+
+
+def is_ixp_active(active_members: list) -> bool:
+    return len(active_members) >= 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ixp-tracker"
-version = "0.14"
+version = "0.15"
 description = "Library to retrieve and manipulate data about IXPs"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from ixp_tracker.models import ASN, IXP
+from ixp_tracker.models import ASN, IXP, IXPMember, IXPMembershipRecord
 
 
 def create_asn_fixture(as_number: int, country: str = "CH"):
@@ -36,3 +36,25 @@ def create_ixp_fixture(peering_db_id: int, country = "MM", last_active: datetime
     )
     ixp.save()
     return ixp
+
+
+def create_member_fixture(ixp, as_number, speed = 10000, is_rs_peer = False, date_left = None, member_since = None, asn_country = "CH"):
+    last_active = date_left or datetime.now(timezone.utc)
+    member_since = member_since or datetime(year=2024, month=4, day=1).date()
+    asn = create_asn_fixture(as_number, asn_country)
+    member = IXPMember(
+        ixp=ixp,
+        asn=asn,
+        last_updated=datetime.now(timezone.utc),
+        last_active=last_active
+    )
+    member.save()
+    membership = IXPMembershipRecord(
+        member=member,
+        start_date=member_since,
+        is_rs_peer=is_rs_peer,
+        speed=speed,
+        end_date=date_left
+    )
+    membership.save()
+    return member

--- a/tests/test_country_stats.py
+++ b/tests/test_country_stats.py
@@ -11,7 +11,7 @@ from tests.test_members_import import create_ixp_fixture
 pytestmark = pytest.mark.django_db
 
 
-class TestLookup:
+class MockLookup:
 
     def __init__(self, default_status: str = "assigned"):
         self.default_status = default_status
@@ -30,7 +30,7 @@ class TestLookup:
 
 
 def test_with_no_data_generates_no_stats():
-    generate_stats(TestLookup())
+    generate_stats(MockLookup())
 
     stats = StatsPerCountry.objects.all()
     assert len(stats) == 249
@@ -42,19 +42,21 @@ def test_generates_stats():
     ixp_one = create_ixp_fixture(123, "CH")
     create_member_fixture(ixp_one, 12345, 500)
     create_member_fixture(ixp_one, 67890, 10000)
+    create_member_fixture(ixp_one, 3456, 10000)
     ixp_two = create_ixp_fixture(124, "CH")
     create_member_fixture(ixp_two, 5050, 6000)
     create_member_fixture(ixp_two, 67890, 10000)
+    create_member_fixture(ixp_two, 3456, 10000)
 
-    generate_stats(TestLookup())
+    generate_stats(MockLookup())
 
     stats = StatsPerCountry.objects.filter(country_code="CH").first()
     # The default fixture does not have a recent last_active date so technically they shouldn't be counted here
     assert stats.ixp_count == 2
     assert stats.asn_count == 5
     assert stats.routed_asn_count == 4
-    assert stats.member_count == 3
-    assert stats.total_capacity == 26.5
+    assert stats.member_count == 4
+    assert stats.total_capacity == 46.5
     assert stats.asns_ixp_member_rate == 0.4
     assert stats.routed_asns_ixp_member_rate == 0.25
 
@@ -62,27 +64,34 @@ def test_generates_stats():
 def test_generates_ixp_counts():
     stats_date = (datetime.now(timezone.utc) - timedelta(weeks=16)).replace(day=1)
     one_month_before = (stats_date - timedelta(days=1)).replace(day=1)
-    one_month_after = (stats_date - timedelta(days=35)).replace(day=1)
-    # currently_active member
+    one_month_after = (stats_date + timedelta(days=35)).replace(day=1)
+    # currently_active with three members
     active = create_ixp_fixture(123, "CH")
     create_member_fixture(active, 12345, 500, member_since=one_month_before, date_left=one_month_after)
+    create_member_fixture(active, 345, 500, member_since=one_month_before, date_left=one_month_after)
+    create_member_fixture(active, 9876, 500, member_since=one_month_before, date_left=one_month_after)
     # member active in the past
     member_in_past = create_ixp_fixture(124, "CH")
     create_member_fixture(member_in_past, 12345, 500, member_since=one_month_before, date_left=one_month_before)
     # member not yet active (as we are generating historical stats there could be members in the future)
-    mmeber_in_future = create_ixp_fixture(125, "CH")
-    create_member_fixture(mmeber_in_future, 12345, 500, member_since=one_month_after, date_left=None)
+    member_in_future = create_ixp_fixture(125, "CH")
+    create_member_fixture(member_in_future, 12345, 500, member_since=one_month_after, date_left=None)
+    # currently_active but only two members
+    not_enough_members = create_ixp_fixture(126, "CH")
+    create_member_fixture(not_enough_members, 8887, 500, member_since=one_month_before, date_left=one_month_after)
+    create_member_fixture(not_enough_members, 7778, 500, member_since=one_month_before, date_left=one_month_after)
 
-    generate_stats(TestLookup())
+    generate_stats(MockLookup(), stats_date)
 
     stats = StatsPerCountry.objects.filter(country_code="CH").first()
     assert stats.ixp_count == 1
+    assert stats.member_count == 3
 
 
 def test_handles_invalid_country():
     create_ixp_fixture(123, "XK")
 
-    generate_stats(TestLookup())
+    generate_stats(MockLookup())
 
     country_stats = StatsPerCountry.objects.filter(country_code="XK").first()
     assert country_stats is None

--- a/tests/test_toggle_ixp_active_status.py
+++ b/tests/test_toggle_ixp_active_status.py
@@ -2,33 +2,19 @@ import pytest
 from datetime import datetime, timedelta, timezone
 
 from ixp_tracker.importers import toggle_ixp_active_status
-from ixp_tracker.models import IXP, IXPMember, IXPMembershipRecord
-from tests.fixtures import create_asn_fixture, create_ixp_fixture
+from ixp_tracker.models import IXP
+from tests.fixtures import create_ixp_fixture, create_member_fixture
 
 pytestmark = pytest.mark.django_db
-processing_date = datetime.utcnow().replace(tzinfo=timezone.utc)
+processing_date = datetime.now(timezone.utc)
 
 
-def test_active_ixp_with_members_remains_active():
+def test_active_ixp_with_3_members_remains_active():
     ixp = create_ixp_fixture(1)
-    asn = create_asn_fixture(12345)
-    member = IXPMember(
-        ixp=ixp,
-        asn=asn,
-        last_updated=ixp.last_updated,
-        last_active=ixp.last_active
-    )
-    member.save()
-    membership = IXPMembershipRecord(
-        member=member,
-        start_date=ixp.created,
-        is_rs_peer=True,
-        speed=1000,
-        end_date=None
-    )
-    membership.save()
+    create_member_fixture(ixp, 12345)
+    create_member_fixture(ixp, 23456)
+    create_member_fixture(ixp, 34567)
 
-    processing_date = datetime.utcnow().replace(tzinfo=timezone.utc)
     toggle_ixp_active_status(processing_date)
 
     updated_ixp = IXP.objects.get(peeringdb_id=1)
@@ -37,25 +23,12 @@ def test_active_ixp_with_members_remains_active():
     assert updated_ixp.last_updated == ixp.last_updated
 
 
-def test_active_ixp_with_member_marked_ended_is_marked_inactive():
+def test_active_ixp_gone_from_three_to_two_active_members_is_marked_inactive():
     ixp = create_ixp_fixture(1)
-    asn = create_asn_fixture(12345)
-    member = IXPMember(
-        ixp=ixp,
-        asn=asn,
-        last_updated=ixp.last_updated,
-        last_active=ixp.last_active
-    )
-    member.save()
     end_date = processing_date.replace(day=1) - timedelta(days=1)
-    membership = IXPMembershipRecord(
-        member=member,
-        start_date=ixp.created,
-        is_rs_peer=True,
-        speed=1000,
-        end_date=end_date
-    )
-    membership.save()
+    create_member_fixture(ixp, 12345)
+    create_member_fixture(ixp, 23456)
+    create_member_fixture(ixp, 34567, date_left=end_date)
 
     toggle_ixp_active_status(processing_date)
 
@@ -65,27 +38,14 @@ def test_active_ixp_with_member_marked_ended_is_marked_inactive():
     assert updated_ixp.last_updated == processing_date
 
 
-def test_inactive_ixp_with_no_active_members_remains_inactive():
+def test_inactive_ixp_with_two_active_members_remains_inactive():
     ixp = create_ixp_fixture(1)
     ixp.active_status = False
     ixp.save()
-    asn = create_asn_fixture(12345)
-    member = IXPMember(
-        ixp=ixp,
-        asn=asn,
-        last_updated=ixp.last_updated,
-        last_active=ixp.last_active
-    )
-    member.save()
     end_date = processing_date.replace(day=1) - timedelta(days=1)
-    membership = IXPMembershipRecord(
-        member=member,
-        start_date=ixp.created,
-        is_rs_peer=True,
-        speed=1000,
-        end_date=end_date
-    )
-    membership.save()
+    create_member_fixture(ixp, 12345)
+    create_member_fixture(ixp, 23456)
+    create_member_fixture(ixp, 34567, date_left=end_date)
 
     toggle_ixp_active_status(processing_date)
 
@@ -95,26 +55,13 @@ def test_inactive_ixp_with_no_active_members_remains_inactive():
     assert updated_ixp.last_updated == ixp.last_updated
 
 
-def test_inactive_ixp_with_active_member_marked_active():
+def test_inactive_ixp_with_three_active_members_marked_active():
     ixp = create_ixp_fixture(1)
     ixp.active_status = False
     ixp.save()
-    asn = create_asn_fixture(12345)
-    member = IXPMember(
-        ixp=ixp,
-        asn=asn,
-        last_updated=ixp.last_updated,
-        last_active=ixp.last_active
-    )
-    member.save()
-    membership = IXPMembershipRecord(
-        member=member,
-        start_date=ixp.created,
-        is_rs_peer=True,
-        speed=1000,
-        end_date=None
-    )
-    membership.save()
+    create_member_fixture(ixp, 12345)
+    create_member_fixture(ixp, 23456)
+    create_member_fixture(ixp, 34567)
 
     toggle_ixp_active_status(processing_date)
 


### PR DESCRIPTION
Think the changes here are actually fairly straight-forward. Obviously historical stats will need to be re-generated when any apps using this are upgraded to this version.