### PR TITLE
Calculate members last month directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+- retrieve previous months members directly rather than relying on previous month's stats
+
 ## 1.3
 - add number of IXP physical locations to IXP objects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ixp-tracker"
-version = "1.3.0"
+version = "1.3.1"
 description = "Library to retrieve and manipulate data about IXPs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_ixp_stats.py
+++ b/tests/test_ixp_stats.py
@@ -158,10 +158,8 @@ def test_adds_member_growth_stats():
     stats_date = datetime(year=2025, month=3, day=1, tzinfo=timezone.utc)
     ixp = IXPFactory(created=stats_date)
     # Has 5 current members
-    create_member_fixture(ixp, membership_properties={"start_date": datetime(year=2023, month=1, day=1)}, quantity=5)
-    last_month = (stats_date - timedelta(days=1)).replace(day=1).date()
-    # Note the fixture would have had 5 members last month but we hardcode the stats to show only 4
-    StatsPerIXPFactory(ixp=ixp, members=4, stats_date=last_month)
+    create_member_fixture(ixp, membership_properties={"start_date": datetime(year=2023, month=1, day=1)}, quantity=4)
+    create_member_fixture(ixp, membership_properties={"start_date": datetime(year=2025, month=2, day=2)})
 
     generate_stats(MockLookup(), stats_date)
 


### PR DESCRIPTION
This remove the dependency on the previous month's stats. Tested local and the generation for the current month goes from 77s to 107s. If that holds across all months on dev/prod then it should be quicker than making the jobs sequential.