### PR TITLE
Ensure we can handle missing fac_count

### DIFF
--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -71,7 +71,9 @@ def import_data(
             # It seems some of the Peering dumps use single quotes so try and load using ast in this case
             backfill_data = ast.literal_eval(backfill_raw)
         ixp_data = backfill_data.get("ix", {"data": []}).get("data", [])
-        process_ixp_data(processing_date, additional_data)(ixp_data)
+        process_ixp_data(
+            processing_date, additional_data, IXP_TRACKER_ENABLE_EVENT_SOURCING
+        )(ixp_data)
         asn_data = backfill_data.get("net", {"data": []}).get("data", [])
         process_asn_data(additional_data)(asn_data)
         member_data = backfill_data.get("netixlan", {"data": []}).get("data", [])
@@ -153,6 +155,11 @@ def process_ixp_data(
                         ixp_data["updated"], "%Y-%m-%dT%H:%M:%SZ"
                     ).replace(microsecond=1, tzinfo=timezone.utc)
                     exists = id_maps.find_by_peeringdb_id(peeringdb_id)
+                    physical_locations = (
+                        int(ixp_data["fac_count"])
+                        if ixp_data.get("fac_count") is not None
+                        else None
+                    )
                     if exists:
                         _ixp = app.update_ixp(
                             exists.aggregate_id,
@@ -167,7 +174,7 @@ def process_ixp_data(
                             int(ixp_data["org_id"]),
                             ixp_data["id"] in manrs_participants,
                             ixp_data["id"] in anchor_hosts,
-                            int(ixp_data["fac_count"]),
+                            physical_locations,
                         )
                         logger.debug(
                             "Updating IXP record from Peering Db",
@@ -187,7 +194,7 @@ def process_ixp_data(
                             ixp_data["id"] in manrs_participants,
                             ixp_data["id"] in anchor_hosts,
                             int(ixp_data["org_id"]),
-                            int(ixp_data["fac_count"]),
+                            physical_locations,
                         )
                         logger.debug(
                             "Creating IXP record from Peering Db",
@@ -219,6 +226,7 @@ def process_ixp_data(
             except Exception as e:
                 logger.warning("Cannot import IXP data", extra={"error": str(e)})
 
+    logger.debug("Processing IXP data", extra={"event_sourcing": enable_event_sourcing})
     return do_process_ixp_data
 
 

--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -28,7 +28,7 @@ class IXPCreated(Event):
     manrs_participant: bool
     anchor_host: bool
     org_id: int
-    physical_locations: int
+    physical_locations: int = None
 
 
 @dataclass
@@ -87,7 +87,7 @@ class IXP(Aggregate):
     manrs_participant: bool = False
     anchor_host: bool = False
     org_id: int
-    physical_locations: int
+    physical_locations: int | None
 
     def created(self, event: IXPCreated):
         self.name = event.name
@@ -229,7 +229,7 @@ class IXPTracker:
         org_id: int,
         manrs_participant: bool,
         anchor_host: bool,
-        physical_locations: int,
+        physical_locations: int | None,
     ):
         ixp = self.es.get_aggregate(aggregate_id, IXP)
         updates = {}
@@ -258,7 +258,10 @@ class IXPTracker:
         if ixp.anchor_host != anchor_host:
             event = AnchorHostChange(ixp, anchor_host=anchor_host)
             self.es.store(event)
-        if ixp.physical_locations != physical_locations:
+        if (
+            ixp.physical_locations != physical_locations
+            and physical_locations is not None
+        ):
             event = PhysicalLocationChange(ixp, physical_locations=physical_locations)
             self.es.store(event)
         event = IXPActiveInPeeringDb(ixp, last_active=str(last_active))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -232,7 +232,7 @@ def test_registers_change_in_anchor_host(faker):
     assert ixp.anchor_host
 
 
-def test_registers_change_in_location_count(faker):
+def test_registers_change_in_location_count_if_both_values_exist(faker):
     mes = MemoryEventStore()
     es = EventStore(IXP_TRACKER_EVENT_MAP, mes)
     app = IXPTracker(es, IXPIdMapProjection())
@@ -259,6 +259,37 @@ def test_registers_change_in_location_count(faker):
 
     assert physical_locations_update.event_type == "PhysicalLocationChange"
     assert ixp.anchor_host is False
+
+
+def test_registers_no_change_in_location_count_if_new_value_is_none(faker):
+    mes = MemoryEventStore()
+    es = EventStore(IXP_TRACKER_EVENT_MAP, mes)
+    app = IXPTracker(es, IXPIdMapProjection())
+
+    ixp = create_ixp(faker, es)
+    original_value = ixp.physical_locations
+
+    ixp = app.update_ixp(
+        ixp.id,
+        ixp.name,
+        ixp.long_name,
+        ixp.city,
+        ixp.website,
+        ixp.country_code,
+        ixp.date_created,
+        ixp.last_updated,
+        faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
+        ixp.org_id,
+        ixp.manrs_participant,
+        ixp.anchor_host,
+        None,
+    )
+
+    [event_created, last_active] = mes.events
+
+    assert event_created.event_type == "IXPCreated"
+    assert last_active.event_type == "IXPActiveInPeeringDb"
+    assert ixp.physical_locations == original_value
 
 
 def create_ixp(faker: Faker, es: EventStore) -> IXP:

--- a/tests/test_ixps_import_es.py
+++ b/tests/test_ixps_import_es.py
@@ -37,6 +37,19 @@ def test_imports_a_new_ixp():
     assert ixp.aggregate_id
 
 
+def test_import_handles_missing_data():
+    new_data = PeeringIXFactory()
+    del new_data["fac_count"]
+    importers.process_ixp_data(
+        datetime.now(timezone.utc), MockLookup(), IXP_TRACKER_ENABLE_EVENT_SOURCING
+    )([new_data])
+
+    ixps = IXPIdMap.objects.all()
+    assert len(ixps) == 1
+    ixp = ixps.first()
+    assert ixp.aggregate_id
+
+
 def test_updates_an_existing_ixp(faker):
     new_data = PeeringIXFactory()
     app = IXPTracker(


### PR DESCRIPTION
Have run locally with this fix and it imports 688 IXPs from the 2019-01 data as expected.