### PR TITLE
Refactoring

### DIFF
--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -199,54 +199,32 @@ def process_ixp_data(
                     last_updated = datetime.strptime(
                         ixp_data["updated"], PEERING_DB_DATE_FORMAT
                     ).replace(tzinfo=timezone.utc)
-                    exists = event_sourcing_app.find_by_peeringdb_id(peeringdb_id)
                     physical_locations = (
                         int(ixp_data["fac_count"])
                         if ixp_data.get("fac_count") is not None
                         else None
                     )
-                    if exists:
-                        _ixp = event_sourcing_app.update_ixp(
-                            exists,
-                            ixp_data["name"],
-                            ixp_data["name_long"],
-                            ixp_data["city"],
-                            ixp_data["website"],
-                            ixp_data["country"],
-                            date_created,
-                            last_updated,
-                            processing_date,
-                            int(ixp_data["org_id"]),
-                            ixp_data["id"] in manrs_participants,
-                            ixp_data["id"] in anchor_hosts,
-                            physical_locations,
-                        )
-                        logger.debug(
-                            "Updating IXP record from Peering Db",
-                            extra={"id": ixp_data["id"]},
-                        )
-                        ixps_updated += 1
-                    else:
-                        _ixp = event_sourcing_app.register_ixp(
-                            ixp_data["name"],
-                            ixp_data["name_long"],
-                            ixp_data["city"],
-                            peeringdb_id,
-                            ixp_data["website"],
-                            ixp_data["country"],
-                            date_created,
-                            last_updated,
-                            processing_date,
-                            ixp_data["id"] in manrs_participants,
-                            ixp_data["id"] in anchor_hosts,
-                            int(ixp_data["org_id"]),
-                            physical_locations,
-                        )
-                        logger.debug(
-                            "Creating IXP record from Peering Db",
-                            extra={"id": ixp_data["id"]},
-                        )
-                        ixps_added += 1
+                    _ixp = event_sourcing_app.import_ixp(
+                        ixp_data["name"],
+                        ixp_data["name_long"],
+                        ixp_data["city"],
+                        peeringdb_id,
+                        ixp_data["website"],
+                        ixp_data["country"],
+                        date_created,
+                        last_updated,
+                        processing_date,
+                        ixp_data["id"] in manrs_participants,
+                        ixp_data["id"] in anchor_hosts,
+                        int(ixp_data["org_id"]),
+                        physical_locations,
+                    )
+                    logger.debug(
+                        "Importing IXP record from Peering Db",
+                        extra={"id": ixp_data["id"]},
+                    )
+                    ixps_updated += 1
+
                 else:
                     _, created = models.IXP.objects.update_or_create(
                         peeringdb_id=ixp_data["id"],
@@ -313,7 +291,6 @@ def process_asn_data(geo_lookup, event_sourcing_app: IXPTracker | None = None):
                 last_updated = dateutil.parser.isoparse(asn_data["updated"])
                 country_code = geo_lookup.get_iso2_country(asn, last_updated)
                 if event_sourcing_app:
-                    exists = event_sourcing_app.get_asn(asn)
                     try:
                         network_type = NetworkType(asn_data["info_type"])
                     except ValueError:
@@ -322,23 +299,14 @@ def process_asn_data(geo_lookup, event_sourcing_app: IXPTracker | None = None):
                         peering_policy = PeeringPolicy(asn_data["policy_general"])
                     except ValueError:
                         peering_policy = PeeringPolicy.UNKNOWN
-                    if exists:
-                        event_sourcing_app.update_asn(
-                            exists,
-                            asn_data["name"],
-                            network_type,
-                            peering_policy,
-                            country_code,
-                        )
-                    else:
-                        event_sourcing_app.register_asn(
-                            asn,
-                            asn_data["name"],
-                            network_type,
-                            peering_policy,
-                            asn_data["id"],
-                            country_code,
-                        )
+                    event_sourcing_app.import_asn(
+                        asn,
+                        asn_data["name"],
+                        network_type,
+                        peering_policy,
+                        asn_data["id"],
+                        country_code,
+                    )
                 else:
                     models.ASN.objects.update_or_create(
                         peeringdb_id=asn_data["id"],

--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -377,22 +377,19 @@ class MemberImportData(TypedDict):
     asn: int
     created_date: datetime
     updated_date: datetime
-    # TODO We're already passing in the processing_date separately so perhaps we should remove this here and just use that
-    last_active: datetime
     is_rs_peer: bool
     port_speed: int
 
 
 class IXPTracker:
     es: EventStore
-    # TODO We only need the ASN lookup for now but we should probably move the other lookups into the app too (e.g. MANRS, RIPE Anchors)
     geo_lookup: ASNGeoLookup
 
     def __init__(self, es: EventStore, geo_lookup: ASNGeoLookup):
         self.es = es
         self.geo_lookup = geo_lookup
 
-    def register_ixp(
+    def import_ixp(
         self,
         name: str,
         long_name: str,
@@ -408,6 +405,23 @@ class IXPTracker:
         org_id: int,
         physical_locations: int,
     ):
+        exists = self.find_by_peeringdb_id(peeringdb_id)
+        if exists:
+            return self._update_ixp(
+                exists,
+                name,
+                long_name,
+                city,
+                website,
+                country_code,
+                created,
+                last_updated,
+                last_active,
+                org_id,
+                manrs_participant,
+                anchor_host,
+                physical_locations,
+            )
         active_status = True
         ixp = IXP(id=uuid4())
         event = IXPCreated(
@@ -431,7 +445,7 @@ class IXPTracker:
         ixp.created(event)
         return ixp
 
-    def update_ixp(
+    def _update_ixp(
         self,
         ixp: IXP,
         name: str,
@@ -492,7 +506,7 @@ class IXPTracker:
         ixp.active_in_peering_db(active_event)
         return ixp
 
-    def register_asn(
+    def import_asn(
         self,
         as_number: int,
         name: str,
@@ -501,47 +515,41 @@ class IXPTracker:
         peeringdb_id: int,
         country_code,
     ):
-        asn = ASN(id=uuid4())
-        event = ASNCreated(
-            asn,
-            as_number,
-            name,
-            network_type.value,
-            peering_policy.value,
-            peeringdb_id,
-            country_code,
-        )
-        self.es.store(event)
-        asn.created(event)
-        return asn
-
-    def update_asn(
-        self,
-        asn: ASN,
-        name: str,
-        network_type: NetworkType,
-        peering_policy: PeeringPolicy,
-        peeringdb_id: int,
-        country_code: str,
-    ):
-        updates = {}
-        if name != asn.name:
-            updates["name"] = name
-        if network_type != asn.network_type:
-            updates["network_type"] = network_type.value
-        if peering_policy != asn.peering_policy:
-            updates["peering_policy"] = peering_policy.value
-        if country_code != asn.country_code:
-            updates["country_code"] = country_code
-        if len(updates.keys()) > 0:
-            event = ASNUpdated(asn, **updates)
+        entity = self.get_asn(as_number)
+        if entity:
+            updates = {}
+            if name != entity.name:
+                updates["name"] = name
+            if network_type != entity.network_type:
+                updates["network_type"] = network_type.value
+            if peering_policy != entity.peering_policy:
+                updates["peering_policy"] = peering_policy.value
+            if country_code != entity.country_code:
+                updates["country_code"] = country_code
+            if len(updates.keys()) > 0:
+                update_event = ASNUpdated(entity, **updates)
+                self.es.store(update_event)
+                entity.updated(update_event)
+            if peeringdb_id != entity.peeringdb_id:
+                peering_id_event = ASNPeeringDbIdChanged(
+                    entity, peeringdb_id=peeringdb_id
+                )
+                self.es.store(peering_id_event)
+                entity.peering_db_id_changed(peering_id_event)
+        else:
+            entity = ASN(id=uuid4())
+            event = ASNCreated(
+                entity,
+                as_number,
+                name,
+                network_type.value,
+                peering_policy.value,
+                peeringdb_id,
+                country_code,
+            )
             self.es.store(event)
-            asn.updated(event)
-        if peeringdb_id != asn.peeringdb_id:
-            peering_id_event = ASNPeeringDbIdChanged(asn, peeringdb_id=peeringdb_id)
-            self.es.store(peering_id_event)
-            asn.peering_db_id_changed(peering_id_event)
-        return asn
+            entity.created(event)
+        return entity
 
     def import_members(
         self,
@@ -566,7 +574,7 @@ class IXPTracker:
                     member["asn"],
                     stringify_date(member["created_date"]),
                     stringify_date(member["updated_date"]),
-                    stringify_date(member["last_active"]),
+                    stringify_date(processing_date),
                     member["is_rs_peer"],
                     member["port_speed"],
                 )
@@ -598,7 +606,7 @@ class IXPTracker:
                     self.es.store(rs_peer_event)
                     ixp.rs_peering_status_change(rs_peer_event)
                 active_event = IXPMemberActiveInPeeringDb(
-                    ixp, member["asn"], stringify_date(member["last_active"])
+                    ixp, member["asn"], stringify_date(processing_date)
                 )
                 self.es.store(active_event)
                 ixp.member_active_in_peering_db(active_event)

--- a/tests/test_app_asn.py
+++ b/tests/test_app_asn.py
@@ -26,7 +26,7 @@ def test_registers_asn(faker: Faker):
     name = faker.company()
     peering_policy = faker.random_element(PeeringPolicy)
     peeringdb_id = faker.random_number(digits=3)
-    asn = app.register_asn(
+    asn = app.import_asn(
         as_number,
         name,
         network_type,
@@ -52,8 +52,8 @@ def test_updates_asn(faker):
     new_network_policy = faker.random_element(NetworkType)
     new_peering_policy = faker.random_element(PeeringPolicy)
     new_country = faker.country_code()
-    app.update_asn(
-        asn,
+    app.import_asn(
+        asn.number,
         new_name,
         new_network_policy,
         new_peering_policy,
@@ -72,8 +72,8 @@ def test_does_not_update_fields_if_not_changed(faker):
 
     asn = create_asn(faker, es)
 
-    app.update_asn(
-        asn,
+    app.import_asn(
+        asn.number,
         asn.name + "X",
         asn.network_type,
         asn.peering_policy,
@@ -95,8 +95,8 @@ def test_records_peeringdb_id_change_as_separate_event(faker):
 
     asn = create_asn(faker, es)
 
-    app.update_asn(
-        asn,
+    app.import_asn(
+        asn.number,
         asn.name,
         asn.network_type,
         asn.peering_policy,

--- a/tests/test_app_ixp.py
+++ b/tests/test_app_ixp.py
@@ -25,7 +25,7 @@ def test_registers_ixp(faker: Faker):
     name = f"{city} - IX"
     long_name = f"{city} Internet Exchange Point"
     peeringdb_id = faker.random_number(digits=3)
-    ixp = app.register_ixp(
+    ixp = app.import_ixp(
         name,
         long_name,
         city,
@@ -59,19 +59,19 @@ def test_updates_main_ixp_details(faker):
     new_city = faker.city()
     new_website = faker.url(schemes=["https"])
     new_country = faker.country_code()
-    app.update_ixp(
-        ixp,
+    app.import_ixp(
         new_name,
         new_long_name,
         new_city,
+        ixp.peeringdb_id,
         new_website,
         new_country,
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
-        faker.random_number(digits=3),
         ixp.manrs_participant,
         ixp.anchor_host,
+        faker.random_number(digits=3),
         ixp.physical_locations,
     )
 
@@ -86,19 +86,19 @@ def test_does_not_update_fields_if_not_changed(faker):
 
     ixp = create_ixp(faker, es)
 
-    app.update_ixp(
-        ixp,
+    app.import_ixp(
         ixp.name + "X",
         ixp.long_name,
         ixp.city,
+        ixp.peeringdb_id,
         ixp.website,
         ixp.country_code,
         ixp.date_created,
         ixp.last_updated,
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
+        False,
+        False,
         ixp.org_id,
-        False,
-        False,
         ixp.physical_locations,
     )
 
@@ -121,19 +121,19 @@ def test_always_updates_last_active(faker):
     ixp = create_ixp(faker, es)
 
     processing_date = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
-    ixp = app.update_ixp(
-        ixp,
+    ixp = app.import_ixp(
         ixp.name,
         ixp.long_name,
         ixp.city,
+        ixp.peeringdb_id,
         ixp.website,
         ixp.country_code,
         ixp.date_created,
         ixp.last_updated,
         processing_date,
+        False,
+        False,
         ixp.org_id,
-        False,
-        False,
         ixp.physical_locations,
     )
 
@@ -149,19 +149,19 @@ def test_registers_change_in_manrs_status(faker):
     ixp = create_ixp(faker, es)
     ixp.manrs_participant = False
 
-    ixp = app.update_ixp(
-        ixp,
+    ixp = app.import_ixp(
         ixp.name,
         ixp.long_name,
         ixp.city,
+        ixp.peeringdb_id,
         ixp.website,
         ixp.country_code,
         ixp.date_created,
         ixp.last_updated,
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
-        ixp.org_id,
         True,
         False,
+        ixp.org_id,
         ixp.physical_locations,
     )
 
@@ -176,19 +176,19 @@ def test_registers_change_in_anchor_host(faker):
     app, es = build_app(mes)
     ixp = create_ixp(faker, es)
 
-    ixp = app.update_ixp(
-        ixp,
+    ixp = app.import_ixp(
         ixp.name,
         ixp.long_name,
         ixp.city,
+        ixp.peeringdb_id,
         ixp.website,
         ixp.country_code,
         ixp.date_created,
         ixp.last_updated,
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
-        ixp.org_id,
         ixp.manrs_participant,
         True,
+        ixp.org_id,
         ixp.physical_locations,
     )
 
@@ -203,19 +203,19 @@ def test_registers_change_in_location_count_if_both_values_exist(faker):
     app, es = build_app(mes)
     ixp = create_ixp(faker, es)
 
-    ixp = app.update_ixp(
-        ixp,
+    ixp = app.import_ixp(
         ixp.name,
         ixp.long_name,
         ixp.city,
+        ixp.peeringdb_id,
         ixp.website,
         ixp.country_code,
         ixp.date_created,
         ixp.last_updated,
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
-        ixp.org_id,
         ixp.manrs_participant,
         ixp.anchor_host,
+        ixp.org_id,
         (ixp.physical_locations + 1),
     )
 
@@ -231,19 +231,19 @@ def test_registers_no_change_in_location_count_if_new_value_is_none(faker):
     ixp = create_ixp(faker, es)
     original_value = ixp.physical_locations
 
-    ixp = app.update_ixp(
-        ixp,
+    ixp = app.import_ixp(
         ixp.name,
         ixp.long_name,
         ixp.city,
+        ixp.peeringdb_id,
         ixp.website,
         ixp.country_code,
         ixp.date_created,
         ixp.last_updated,
         faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
-        ixp.org_id,
         ixp.manrs_participant,
         ixp.anchor_host,
+        ixp.org_id,
         None,
     )
 

--- a/tests/test_app_member.py
+++ b/tests/test_app_member.py
@@ -38,7 +38,7 @@ def test_imports_member(faker: Faker):
     assert len(ixp.get_members()) == 0
 
     imported = app.import_members(
-        ixp, [create_member_import_data(faker, date_now, asn.number)], date_now
+        ixp, [create_member_import_data(faker, asn.number)], date_now
     )
 
     members = imported.get_members()
@@ -59,8 +59,8 @@ def test_imports_multiple_members(faker: Faker):
     imported = app.import_members(
         ixp,
         [
-            create_member_import_data(faker, date_now, asn1.number),
-            create_member_import_data(faker, date_now, asn2.number),
+            create_member_import_data(faker, asn1.number),
+            create_member_import_data(faker, asn2.number),
         ],
         date_now,
     )
@@ -81,7 +81,7 @@ def test_adds_new_membership_for_existing_member_marked_as_left(faker):
         "end_date": datetime(year=2018, month=7, day=13, tzinfo=timezone.utc),
     }
     create_member(faker, es, ixp, asn, membership_properties)
-    member_import_data = create_member_import_data(faker, date_now, asn.number)
+    member_import_data = create_member_import_data(faker, asn.number)
 
     ixp = app.import_members(ixp, [member_import_data], date_now)
 
@@ -103,7 +103,6 @@ def test_extends_membership_for_member_marked_as_left_if_created_before_date_lef
     create_member(faker, es, ixp, asn, membership_properties)
     member_import_data = create_member_import_data(
         faker,
-        date_now,
         asn.number,
         created_date=datetime(year=2018, month=6, day=18, tzinfo=timezone.utc),
     )
@@ -130,7 +129,7 @@ def test_ensure_multiple_member_entries_does_not_trigger_multiple_new_membership
 
     date_after_date_left = datetime(2023, 9, 24, tzinfo=timezone.utc)
     member_data_with_created_date_after_date_left = create_member_import_data(
-        faker, date_now, asn.number, created_date=date_after_date_left
+        faker, asn.number, created_date=date_after_date_left
     )
 
     ixp = app.import_members(
@@ -161,7 +160,7 @@ def test_do_not_add_new_membership_for_same_created_date(faker):
     # As we always create a new membership record if the most recent one has ended, for multiple ASN-IX combos this
     # could result in multiple new memberships being created
     member_import = create_member_import_data(
-        faker, date_now, asn.number, created_date=created_date
+        faker, asn.number, created_date=created_date
     )
 
     ixp = app.import_members(ixp, [member_import], date_now)
@@ -181,14 +180,13 @@ def build_app(
 
 
 def create_member_import_data(
-    faker, date_now, asn: int, created_date: datetime | None = None
+    faker, asn: int, created_date: datetime | None = None
 ) -> MemberImportData:
     return {
         "asn": asn,
         "created_date": created_date
         or faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
         "updated_date": faker.date_time_between(start_date="-1d", tzinfo=timezone.utc),
-        "last_active": date_now,
         "is_rs_peer": faker.boolean(),
         "port_speed": faker.random_number(digits=5),
     }

--- a/tests/test_asns_import_es.py
+++ b/tests/test_asns_import_es.py
@@ -1,6 +1,3 @@
-import json
-from datetime import datetime, timezone
-
 import pytest
 import responses
 
@@ -8,19 +5,9 @@ from django_test_app.settings import IXP_TRACKER_PEERING_DB_URL
 from ixp_tracker import importers
 from ixp_tracker.ixp_tracker import NetworkType, PeeringPolicy
 
-from .fixtures import ASNFactory, PeeringASNFactory, build_app
+from .fixtures import PeeringASNFactory, build_app, TestLookup
 
 pytestmark = pytest.mark.django_db
-
-
-class TestLookup:
-    def get_iso2_country(self, asn: int, as_at: datetime) -> str:
-        assert as_at <= datetime.now(timezone.utc)
-        assert asn > 0
-        return "AU"
-
-    def get_status(self, asn: int, as_at: datetime) -> str:
-        pass
 
 
 def test_with_empty_response_does_nothing():
@@ -66,32 +53,27 @@ def test_uses_defaults_for_network_type_and_peering_policy_if_invalid():
     assert asn.peering_policy == PeeringPolicy.UNKNOWN
 
 
-def test_updates_existing_data():
-    updated_asn_data = PeeringASNFactory()
-    ASNFactory(
-        number=updated_asn_data["asn"],
-        peeringdb_id=updated_asn_data["id"],
-        last_updated=datetime(2024, 5, 1, tzinfo=timezone.utc),
+def test_updates_existing_data(faker):
+    name = faker.nic_handle(suffix="FAKE")
+    updated_asn_data = PeeringASNFactory(name=(name + "new"))
+    app = build_app()
+    app.import_asn(
+        updated_asn_data["asn"],
+        name,
+        NetworkType.CONTENT,
+        PeeringPolicy.OPEN,
+        updated_asn_data["id"],
+        faker.country_code(),
     )
-    with responses.RequestsMock() as rsps:
-        app = build_app()
-        rsps.get(
-            url=IXP_TRACKER_PEERING_DB_URL
-            + "/net?updated__gte=2024-05-01&limit=200&skip=0",
-            body=json.dumps({"data": [updated_asn_data]}),
-        )
-        rsps.get(
-            url=IXP_TRACKER_PEERING_DB_URL
-            + "/net?updated__gte=2024-05-01&limit=200&skip=200",
-            body=json.dumps({"data": []}),
-        )
-        importers.import_asns(TestLookup(), False, es_app=app)
 
-        asns = app.get_all_asns()
-        assert len(asns) == 1
-        updated = asns.pop(0)
-        assert updated.name == updated_asn_data["name"]
-        assert updated.country_code == "AU"
+    processor = importers.process_asn_data(TestLookup(default_country="AU"), app)
+    processor([updated_asn_data])
+
+    asns = app.get_all_asns()
+    assert len(asns) == 1
+    updated = asns.pop(0)
+    assert updated.name == updated_asn_data["name"]
+    assert updated.country_code == "AU"
 
 
 def test_handles_errors_with_source_data():

--- a/tests/test_ixps_import_es.py
+++ b/tests/test_ixps_import_es.py
@@ -44,7 +44,7 @@ def test_updates_an_existing_ixp(faker):
     city = faker.city()
     name = f"{city} - IX"
     long_name = f"{city} Internet Exchange Point"
-    app.register_ixp(
+    app.import_ixp(
         name,
         long_name,
         city,


### PR DESCRIPTION
See commits for specific refactorings but most of this is combining the register/update methods into a single "import" method for each aggregate.

I've not pulled the other data lookups into the IXPTracker app as they lookup based on PeeringDB id. Might need more thought as the IXPTracker internally should be as agnostic as possible to the source of the data. We can probably relook at this as and when we import from another source.