### PR TITLE
Pass aggregate into projection

### DIFF
--- a/ixp_tracker/event_store.py
+++ b/ixp_tracker/event_store.py
@@ -69,14 +69,14 @@ class Projection(ABC):
         if self.__getattribute__("events") is None:
             self.events = []
 
-    def handle(self, event: StoredEvent):
+    def handle(self, event: StoredEvent, aggregate: T):
         if event.aggregate_type not in self.aggregate_types:
             return
         if event.event_type not in self.events:
             return
-        self.do_handle(event)
+        self.do_handle(event, aggregate)
 
-    def do_handle(self, event: StoredEvent):
+    def do_handle(self, event: StoredEvent, aggregate: T):
         pass
 
 
@@ -141,10 +141,10 @@ class EventStore:
             data=event_data,
         )
         self.db.save_event(stored_event)
-        for listener in self.listeners:
-            listener.handle(stored_event)
-
         aggregate.apply_event(event, stored_event.event_sequence)
+        for listener in self.listeners:
+            listener.handle(stored_event, aggregate)
+
         return aggregate
 
     def get_aggregate(self, aggregate_id: UUID, aggregate_type: type[T]) -> T:

--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -383,7 +383,7 @@ class IXPIdMapProjection(Projection):
     aggregate_types = [IXP.__name__]
     events = [IXPCreated.__name__]
 
-    def do_handle(self, event: StoredEvent):
+    def do_handle(self, event: StoredEvent, aggregate: Aggregate):
         existing = IXPIdMap.objects.filter(aggregate_id=event.aggregate_id)
         if existing.count() > 0:
             return
@@ -414,7 +414,7 @@ class ASNList(Projection):
     aggregate_types = [ASN.__name__]
     events = [ASNCreated.__name__]
 
-    def do_handle(self, event: StoredEvent):
+    def do_handle(self, event: StoredEvent, asn: Aggregate):
         existing = ASNMap.objects.filter(aggregate_id=event.aggregate_id)
         if existing.count() > 0:
             return

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -387,7 +387,7 @@ class TestProjection(Projection):
 
     handled = False
 
-    def do_handle(self, event: StoredEvent):
+    def do_handle(self, event: StoredEvent, aggregate: Aggregate):
         self.handled = True
 
 

--- a/tests/test_asn_list_projection.py
+++ b/tests/test_asn_list_projection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ixp_tracker.ixp_tracker import ASNList
+from ixp_tracker.ixp_tracker import ASNList, ASN
 from ixp_tracker.models import ASNMap
 from tests.fixtures import StoredEventFactory
 
@@ -17,7 +17,7 @@ def test_adds_new_asn(faker):
     current = ASNMap.objects.all()
     assert current.count() == 0
 
-    projection.handle(event)
+    projection.handle(event, ASN(event.aggregate_id))
 
     saved = ASNMap.objects.get(aggregate_id=event.aggregate_id)
     assert saved.asn == asn
@@ -29,11 +29,12 @@ def test_handles_duplicate_events(faker):
     event = StoredEventFactory(
         event_type="ASNCreated", aggregate_type="ASN", data={"as_number": asn}
     )
+    aggregate = ASN(event.aggregate_id)
 
     # This shouldn't happen but if it does we just handle it silently
     # If this becomes a problem we could add event sequence tracking to projections
-    projection.handle(event)
-    projection.handle(event)
+    projection.handle(event, aggregate)
+    projection.handle(event, aggregate)
 
     saved = ASNMap.objects.all()
     assert saved.count() == 1

--- a/tests/test_isoc_id_projection.py
+++ b/tests/test_isoc_id_projection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ixp_tracker.ixp_tracker import IXPIdMapProjection
+from ixp_tracker.ixp_tracker import IXPIdMapProjection, IXP
 from ixp_tracker.models import IXPIdMap
 from tests.fixtures import StoredEventFactory, IXPIdMapFactory, IXPFactory
 
@@ -10,11 +10,12 @@ pytestmark = pytest.mark.django_db
 def test_creates_new_isoc_id():
     projection = IXPIdMapProjection()
     event = StoredEventFactory(event_type="IXPCreated", aggregate_type="IXP")
+    ixp = IXP(event.aggregate_id)
 
     current = IXPIdMap.objects.all()
     assert current.count() == 0
 
-    projection.handle(event)
+    projection.handle(event, ixp)
 
     saved = IXPIdMap.objects.get(aggregate_id=event.aggregate_id)
     assert saved.id > 0
@@ -24,11 +25,12 @@ def test_creates_new_isoc_id():
 def test_handles_duplicate_events():
     projection = IXPIdMapProjection()
     event = StoredEventFactory(event_type="IXPCreated", aggregate_type="IXP")
+    ixp = IXP(event.aggregate_id)
 
     # This shouldn't happen but if it does we just handle it silently
     # If this becomes a problem we could add event sequence tracking to projections
-    projection.handle(event)
-    projection.handle(event)
+    projection.handle(event, ixp)
+    projection.handle(event, ixp)
 
     saved = IXPIdMap.objects.all()
     assert saved.count() == 1
@@ -42,11 +44,12 @@ def test_saves_peeringdb_id(faker):
         aggregate_type="IXP",
         data={"peeringdb_id": peeringdb_id},
     )
+    ixp = IXP(event.aggregate_id)
 
     current = IXPIdMap.objects.all()
     assert current.count() == 0
 
-    projection.handle(event)
+    projection.handle(event, ixp)
 
     saved = IXPIdMap.objects.get(aggregate_id=event.aggregate_id)
     assert saved.peeringdb_id == peeringdb_id
@@ -81,15 +84,16 @@ def test_uses_existing_isoc_id_when_importing_an_ixp_for_the_first_time(faker):
     IXPIdMapFactory()
     projection = IXPIdMapProjection()
     peeringdb_id = faker.random_number(digits=3)
-    ixp = IXPFactory(peeringdb_id=peeringdb_id)
+    legacy_ixp = IXPFactory(peeringdb_id=peeringdb_id)
     event = StoredEventFactory(
         event_type="IXPCreated",
         aggregate_type="IXP",
         data={"peeringdb_id": peeringdb_id},
     )
+    ixp = IXP(event.aggregate_id)
 
-    projection.handle(event)
+    projection.handle(event, ixp)
 
     saved = IXPIdMap.objects.get(aggregate_id=event.aggregate_id)
     assert saved.peeringdb_id == peeringdb_id
-    assert saved.id == ixp.id
+    assert saved.id == legacy_ixp.id

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.fixtures import StoredEventFactory, TestProjection
+from tests.fixtures import StoredEventFactory, TestProjection, TestAggregate
 
 # We need to use the db/Django-stored events here for now as the `EventStore` passes those to all projections
 # even though the projection we're testing doesn't need a db. Perhaps a future refactoring?
@@ -11,9 +11,10 @@ def test_handles_specified_aggregate():
     event = StoredEventFactory(
         event_type="CreatedTestAggregate", aggregate_type="TestAggregate"
     )
+    aggregate = TestAggregate(event.aggregate_id)
     projection = TestProjection()
 
-    projection.handle(event)
+    projection.handle(event, aggregate)
 
     assert projection.handled
 
@@ -22,9 +23,10 @@ def test_does_not_handle_different_aggregate():
     event = StoredEventFactory(
         event_type="CreatedTestAggregate", aggregate_type="SecondAggregate"
     )
+    aggregate = TestAggregate(event.aggregate_id)
     projection = TestProjection()
 
-    projection.handle(event)
+    projection.handle(event, aggregate)
 
     assert projection.handled is False
 
@@ -33,8 +35,9 @@ def test_does_not_handle_different_event():
     event = StoredEventFactory(
         event_type="AnotherEvent", aggregate_type="TestAggregate"
     )
+    aggregate = TestAggregate(event.aggregate_id)
     projection = TestProjection()
 
-    projection.handle(event)
+    projection.handle(event, aggregate)
 
     assert projection.handled is False


### PR DESCRIPTION
This was the performance improvement I referenced. As we now have the updated Aggregate when we store the event we can easily pass it in to the Projection and in some cases this removes the need to reload the Aggregate there.