### PR TITLE
Handle members left and inactive ixps better

### DIFF
--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -346,7 +346,7 @@ def process_member_data(
     def do_process_member_data(all_member_data):
         all_member_data = dedupe_member_data(all_member_data)
         if event_sourcing_app:
-            ixp_data = {}
+            ixp_member_data = {}
             for member_data in all_member_data:
                 asn = int(member_data["asn"])
                 created_date = datetime.strptime(
@@ -366,31 +366,48 @@ def process_member_data(
                     "is_rs_peer": is_rs_peer,
                     "port_speed": port_speed,
                 }
-                seen = ixp_data.get(ix_id)
+                seen = ixp_member_data.get(ix_id)
                 if not seen:
-                    ixp_data[ix_id] = [import_data]
+                    ixp_member_data[ix_id] = [import_data]
                 else:
-                    ixp_data[ix_id] += [import_data]
-            for ixp in ixp_data:
-                log_data = {"ixp": ixp}
-                logger.debug("Importing IXP members", extra=log_data)
-                ixp_entity = event_sourcing_app.find_by_peeringdb_id(ixp)
-                if ixp_entity is None:
-                    logger.warning("Cannot find IXP", extra=log_data)
-                    continue
-                ixp_entity = event_sourcing_app.import_members(
-                    ixp_entity, ixp_data[ixp], processing_date
-                )
-                if ixp_entity is None:
-                    logger.warning("Cannot import IXP members", extra=log_data)
-                else:
-                    log_data["member_count"] = len(ixp_entity.get_members(True))
+                    ixp_member_data[ix_id] += [import_data]
+            ixps = event_sourcing_app.get_all_ixps()
+            updated = []
+            for peeringdb_id in ixp_member_data:
+                try:
+                    log_data = {"ixp": peeringdb_id}
+                    logger.debug("Importing IXP members", extra=log_data)
+                    ixp = next(
+                        (ixp for ixp in ixps if ixp.peeringdb_id == peeringdb_id), None
+                    )
+                    if ixp is None:
+                        logger.warning("Cannot find IXP", extra=log_data)
+                        continue
+                    ixp = event_sourcing_app.import_members(
+                        ixp, ixp_member_data[peeringdb_id], processing_date
+                    )
+                    log_data["member_count"] = len(ixp.get_members(True))
+                    updated.append(ixp.id)
                     logger.debug("Imported IXP members", extra=log_data)
+                except Exception as e:
+                    logger.warning(
+                        "Cannot import IXP members",
+                        extra={"ixp": peeringdb_id, "error": str(e)},
+                    )
+            for ixp in ixps:
+                if ixp.id in updated:
+                    continue
+                logger.debug(
+                    "Marking IXP members inactive", extra={"ixp_id": ixp.peeringdb_id}
+                )
+                event_sourcing_app.check_ixp_inactive(ixp, processing_date)
         else:
             for member_data in all_member_data:
                 log_data = {"asn": member_data["asn"], "ixp": member_data["ix_id"]}
                 try:
-                    ixp = models.IXP.objects.get(peeringdb_id=member_data["ix_id"])
+                    peeringdb_id = models.IXP.objects.get(
+                        peeringdb_id=member_data["ix_id"]
+                    )
                 except models.IXP.DoesNotExist:
                     logger.warning("Cannot find IXP")
                     continue
@@ -400,7 +417,7 @@ def process_member_data(
                     logger.warning("Cannot find ASN")
                     continue
                 member, created = models.IXPMember.objects.update_or_create(
-                    ixp=ixp,
+                    ixp=peeringdb_id,
                     asn=asn,
                     defaults={
                         "last_updated": member_data["updated"],

--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -55,6 +55,26 @@ class ManrsStatusChange(DomainEvent):
     manrs_participant: bool
 
 
+@dataclass()
+class IXPBecameActive(DomainEvent):
+    active_status: bool
+
+    def __init__(self, active_status: bool = True):
+        if not active_status:
+            raise RuntimeError("IXPBecameActive must set status to True")
+        self.active_status = True
+
+
+@dataclass()
+class IXPBecameInactive(DomainEvent):
+    active_status: bool
+
+    def __init__(self, active_status: bool = False):
+        if active_status:
+            raise RuntimeError("IXPBecameInactive must set status to False")
+        self.active_status = False
+
+
 @dataclass
 class AnchorHostChange(DomainEvent):
     anchor_host: bool
@@ -168,6 +188,12 @@ class IXP(Aggregate):
             self.last_updated = datetime.strptime(event.last_updated, DATE_FORMAT)
         if not isinstance(event.org_id, ValueNotChanged):
             self.org_id = event.org_id
+
+    def became_active(self, event: IXPBecameActive):
+        self.active_status = event.active_status
+
+    def became_inactive(self, event: IXPBecameInactive):
+        self.active_status = event.active_status
 
     def manrs_status_change(self, event: ManrsStatusChange):
         self.manrs_participant = event.manrs_participant
@@ -337,6 +363,8 @@ IXP_TRACKER_EVENT_MAP = {
     ASNUpdated.__name__: ASNUpdated,
     ManrsStatusChange.__name__: ManrsStatusChange,
     IXPActiveInPeeringDb.__name__: IXPActiveInPeeringDb,
+    IXPBecameActive.__name__: IXPBecameActive,
+    IXPBecameInactive.__name__: IXPBecameInactive,
     IXPCreated.__name__: IXPCreated,
     IXPUpdated.__name__: IXPUpdated,
     IXPMemberActiveInPeeringDb.__name__: IXPMemberActiveInPeeringDb,
@@ -472,7 +500,7 @@ class IXPTracker:
                 anchor_host,
                 physical_locations,
             )
-        active_status = True
+        active_status = False
         ixp = IXP(id=uuid4())
         event = IXPCreated(
             name,
@@ -591,7 +619,7 @@ class IXPTracker:
         ixp: IXP,
         ixp_data: list[MemberImportData],
         processing_date: datetime,
-    ):
+    ) -> IXP:
         existing_members = ixp.get_members(True)
         for member in ixp_data:
             as_entity = self.get_asn(member["asn"])
@@ -642,6 +670,11 @@ class IXPTracker:
                 )
                 ixp = self.es.store(ixp, active_event)
 
+        ixp = self.check_ixp_inactive(ixp, processing_date)
+        self.es.save_snapshot(ixp)
+        return ixp
+
+    def check_ixp_inactive(self, ixp: IXP, processing_date: datetime) -> IXP:
         members = ixp.get_members()
         members_left = check_if_members_have_left(
             members, processing_date, self.geo_lookup
@@ -649,7 +682,13 @@ class IXPTracker:
         for member_left in members_left:
             left_event = IXPMemberLeft(member_left[0], stringify_date(member_left[1]))
             ixp = self.es.store(ixp, left_event)
-        self.es.save_snapshot(ixp)
+        members = ixp.get_members()
+        if ixp.active_status is False and len(members) >= 3:
+            active_event = IXPBecameActive()
+            ixp = self.es.store(ixp, active_event)
+        elif ixp.active_status is True and len(members) < 3:
+            inactive_event = IXPBecameInactive()
+            ixp = self.es.store(ixp, inactive_event)
         return ixp
 
     def find_by_peeringdb_id(self, peeringdb_id: int) -> IXP | None:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -33,6 +33,7 @@ from ixp_tracker.ixp_tracker import (
     stringify_date,
     IXPMemberJoined,
     IXPMemberLeft,
+    IXPBecameActive,
 )
 import ixp_tracker.models as legacy
 from ixp_tracker.models import (
@@ -440,7 +441,7 @@ def build_app() -> IXPTracker:
     return app
 
 
-def create_ixp(faker: Faker, es: EventStore) -> IXP:
+def create_ixp(faker: Faker, es: EventStore, active_status=False) -> IXP:
     city = faker.city()
     name = f"{city} - IX"
     long_name = f"{city} Internet Exchange Point"
@@ -452,7 +453,7 @@ def create_ixp(faker: Faker, es: EventStore) -> IXP:
         city,
         peeringdb_id,
         faker.url(schemes=["https"]),
-        True,
+        False,
         faker.country_code(),
         stringify_date(faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)),
         stringify_date(faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)),
@@ -462,7 +463,10 @@ def create_ixp(faker: Faker, es: EventStore) -> IXP:
         faker.random_number(digits=3),
         faker.random_number(digits=2),
     )
-    return es.store(ixp, event)
+    ixp = es.store(ixp, event)
+    if active_status:
+        ixp = es.store(ixp, IXPBecameActive())
+    return ixp
 
 
 def create_asn(faker: Faker, es: EventStore, country_code: str | None = None) -> ASN:

--- a/tests/test_app_ixp.py
+++ b/tests/test_app_ixp.py
@@ -44,6 +44,8 @@ def test_registers_ixp(faker: Faker):
     assert ixp.name == name
     assert ixp.long_name == long_name
     assert ixp.peeringdb_id == peeringdb_id
+    # Always mark a newly-imported IXP as inactive as we import members after the IXP
+    assert ixp.active_status is False
 
     isoc_id = app.find_by_peeringdb_id(peeringdb_id)
     assert isoc_id is not None

--- a/tests/test_app_member.py
+++ b/tests/test_app_member.py
@@ -168,6 +168,52 @@ def test_do_not_add_new_membership_for_same_created_date(faker):
     assert len(ixp.get_members()) == 1
 
 
+def test_marks_ixp_active_if_has_three_members(
+    faker,
+):
+    mes = MemoryEventStore()
+    app, es = build_app(mes)
+    ixp = create_ixp(faker, es)
+    member_import_data = []
+    for _ in range(1, 4):
+        asn = create_asn(faker, es)
+        member_import_data.append(create_member_import_data(faker, asn.number))
+
+    assert ixp.active_status is False
+
+    ixp = app.import_members(ixp, member_import_data, date_now)
+
+    assert ixp.active_status is True
+
+
+def test_marks_ixp_inactive_if_members_drops_below_three(
+    faker,
+):
+    mes = MemoryEventStore()
+    app, es = build_app(mes)
+    ixp = create_ixp(faker, es, True)
+    member_import_data = []
+    # Create 3 existing members
+    for member_count in range(1, 4):
+        asn = create_asn(faker, es)
+        create_member(
+            faker,
+            es,
+            ixp,
+            asn,
+            {"last_active": datetime(year=2023, month=7, day=13, tzinfo=timezone.utc)},
+        )
+        if member_count < 3:
+            # But only 2 existing members in the new import
+            member_import_data.append(create_member_import_data(faker, asn.number))
+
+    assert ixp.active_status is True
+
+    ixp = app.import_members(ixp, member_import_data, date_now)
+
+    assert ixp.active_status is False
+
+
 def build_app(
     es_db: EventStorePersistence | None = None,
     geo_lookup: ASNGeoLookup | None = None,

--- a/tests/test_members_import_es.py
+++ b/tests/test_members_import_es.py
@@ -93,6 +93,32 @@ def test_updates_member(faker):
     assert updated.last_active > last_active
 
 
+def test_marks_members_left_if_ixp_not_referenced_in_import(faker):
+    app, es = build_app()
+    ixp = create_ixp(faker, es, True)
+    # Create 3 existing members
+    for member_count in range(1, 4):
+        asn = create_asn(faker, es)
+        create_member(
+            faker,
+            es,
+            ixp,
+            asn,
+            {"last_active": datetime(year=2023, month=7, day=13, tzinfo=timezone.utc)},
+        )
+    assert ixp.active_status is True
+
+    processor = importers.process_member_data(date_now, TestLookup(), app)
+    processor([])
+
+    ixp = es.get_aggregate(ixp.id, IXP)
+    active_members = ixp.get_members()
+    assert len(active_members) == 0
+    all_members = ixp.get_members(True)
+    assert len(all_members) == 3
+    assert ixp.active_status is False
+
+
 def build_app(
     es_db: EventStorePersistence | None = None,
 ) -> tuple[IXPTracker, EventStore]:


### PR DESCRIPTION
I think this fixes the issue discussed earlier where we're not updating IXPs (and their members) which don't appear in the import data. I also realised that we weren't toggling the IXP active status at all.