### PR TITLE
Ensure zz as stays marked left

### DIFF
--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -189,6 +189,13 @@ class IXPTracker:
                 logger.warning("Cannot find AS", extra={"asn": member["asn"]})
                 continue
             existing_member = existing_members.get(member["asn"])
+            member_registered_to_zz_and_has_left_already = (
+                existing_member
+                and existing_member.date_left is not None
+                and as_zz_country_check(member["asn"], processing_date, self.geo_lookup)
+            )
+            if member_registered_to_zz_and_has_left_already:
+                continue
             member_has_rejoined = (
                 existing_member
                 and existing_member.date_left is not None
@@ -295,13 +302,28 @@ def check_if_members_have_left(
             ).replace(day=1)
             end_of_month = start_of_month_after_last_active - timedelta(days=1)
             members_left.append((member_asn, end_of_month))
-        if (
-            member.date_left is None
-            and geo_lookup.get_iso2_country(member_asn, processing_date) == "ZZ"
-            and geo_lookup.get_status(member_asn, processing_date) != "assigned"
+        if member.date_left is None and as_zz_country_check(
+            member_asn, processing_date, geo_lookup
         ):
             end_of_last_month_active = member.last_active.replace(day=1) - timedelta(
                 days=1
             )
             members_left.append((member_asn, end_of_last_month_active))
     return members_left
+
+
+def as_zz_country_check(asn: int, as_at: datetime, geo_lookup: ASNGeoLookup) -> bool:
+    # AS112 is a special case, see https://www.as112.net). It's marked as registered to country ZZ in NRO so we ignore it here
+    if asn == 112:
+        return False
+    country = geo_lookup.get_iso2_country(asn, as_at)
+    status = geo_lookup.get_status(asn, as_at)
+    if country != "ZZ":
+        return False
+    if status == "assigned":
+        logger.warning(
+            "AS registered to ZZ and marked as assigned",
+            extra={"asn": asn, "date": as_at},
+        )
+        return False
+    return True

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -470,14 +470,19 @@ def create_ixp(faker: Faker, es: EventStore, active_status=False) -> IXP:
     return ixp
 
 
-def create_asn(faker: Faker, es: EventStore, country_code: str | None = None) -> ASN:
-    as_number = faker.random_number(digits=5)
+def create_asn(
+    faker: Faker,
+    es: EventStore,
+    country_code: str | None = None,
+    asn: int | None = None,
+) -> ASN:
+    as_number = asn or faker.random_number(digits=5)
     network_type = faker.random_element(NetworkType)
     name = faker.company()
     peering_policy = faker.random_element(PeeringPolicy)
     peeringdb_id = faker.random_number(digits=3)
     country_code = country_code or faker.country_code()
-    asn = ASN(id=uuid4())
+    asn_entity = ASN(id=uuid4())
     event = ASNCreated(
         as_number,
         name,
@@ -486,7 +491,7 @@ def create_asn(faker: Faker, es: EventStore, country_code: str | None = None) ->
         peeringdb_id,
         country_code,
     )
-    return es.store(asn, event)
+    return es.store(asn_entity, event)
 
 
 def create_member(

--- a/tests/test_app_member.py
+++ b/tests/test_app_member.py
@@ -213,6 +213,52 @@ def test_marks_ixp_inactive_if_members_drops_below_three(
     assert ixp.active_status is False
 
 
+def test_member_marked_left_due_to_zz_country_registration_is_not_imported(faker):
+    mes = MemoryEventStore()
+    app, es = build_app(
+        mes, TestLookup(default_country="ZZ", default_status="reserved")
+    )
+    ixp = create_ixp(faker, es)
+    asn = create_asn(faker, es)
+    membership_properties = {
+        "end_date": datetime(year=2023, month=7, day=13, tzinfo=timezone.utc),
+    }
+    create_member(faker, es, ixp, asn, membership_properties)
+    member_import_data = create_member_import_data(faker, asn.number)
+
+    sequence_before_import = ixp.sequence
+    imported_member = ixp.get_members(True)[asn.number]
+
+    ixp = app.import_members(ixp, [member_import_data], date_now)
+
+    updated_member = ixp.get_members(True)[asn.number]
+    # date_left should not be updated in this case
+    assert updated_member.date_left == imported_member.date_left
+    # no extra events should have been added
+    assert ixp.sequence == sequence_before_import
+
+
+def test_as112_is_marked_as_rejoined(faker):
+    # Normally an AS with country ZZ that has been marked as left would be ignored
+    # But we want AS112 to be considered in this case as it probably means it has left and rejoined
+    mes = MemoryEventStore()
+    app, es = build_app(
+        mes, TestLookup(default_country="ZZ", default_status="reserved")
+    )
+    ixp = create_ixp(faker, es)
+    asn = create_asn(faker, es, asn=112)
+    membership_properties = {
+        "end_date": datetime(year=2023, month=7, day=13, tzinfo=timezone.utc),
+    }
+    create_member(faker, es, ixp, asn, membership_properties)
+    member_import_data = create_member_import_data(faker, asn.number)
+
+    ixp = app.import_members(ixp, [member_import_data], date_now)
+
+    updated_member = ixp.get_members(True)[asn.number]
+    assert updated_member.date_left is None
+
+
 def build_app(
     es_db: EventStorePersistence | None = None,
     geo_lookup: ASNGeoLookup | None = None,
@@ -220,7 +266,7 @@ def build_app(
     es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
     es.add_listener(IXPIdMapProjection())
     es.add_listener(ASNList())
-    app = IXPTracker(es, geo_lookup or TestLookup())
+    app = IXPTracker(es, geo_lookup or TestLookup(default_country="US"))
     return app, es
 
 

--- a/tests/test_as_zz_country_check.py
+++ b/tests/test_as_zz_country_check.py
@@ -1,0 +1,39 @@
+from datetime import timezone
+
+from ixp_tracker.ixp_tracker import as_zz_country_check
+from tests.fixtures import TestLookup
+
+
+def test_as_not_registered_to_zz_returns_false(faker):
+    asn = faker.random_number(digits=5)
+    as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
+
+    assert as_zz_country_check(asn, as_at, TestLookup(default_country="US")) is False
+
+
+def test_as_registered_to_zz_and_not_assigned_returns_true(faker):
+    asn = faker.random_number(digits=5)
+    as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
+
+    assert as_zz_country_check(
+        asn, as_at, TestLookup(default_country="ZZ", default_status="reserved")
+    )
+
+
+def test_as_registered_to_zz_but_assigned_returns_false(faker):
+    asn = faker.random_number(digits=5)
+    as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
+
+    assert (
+        as_zz_country_check(
+            asn, as_at, TestLookup(default_country="ZZ", default_status="assigned")
+        )
+        is False
+    )
+
+
+def test_as112_returns_false(faker):
+    asn = 112
+    as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
+
+    assert as_zz_country_check(asn, as_at, TestLookup(default_country="ZZ")) is False

--- a/tests/test_check_if_members_have_left.py
+++ b/tests/test_check_if_members_have_left.py
@@ -27,6 +27,26 @@ def test_marks_member_as_left_that_is_no_longer_active(faker):
     assert members_left[0][1] == expected_end_date
 
 
+def test_marks_as112_as_left_if_no_longer_active(faker):
+    first_day_of_month = date_now.replace(day=1)
+    last_day_of_last_month = first_day_of_month - timedelta(days=1)
+    date_more_than_month_ago = last_day_of_last_month - timedelta(days=17)
+
+    as_number = 112
+    members: dict[int, IXPMemberDetails] = {
+        as_number: create_member_details(
+            faker, date_more_than_month_ago, date_more_than_month_ago
+        )
+    }
+
+    members_left = check_if_members_have_left(members, date_now, TestLookup())
+
+    expected_end_date = last_day_of_last_month
+    assert len(members_left) == 1
+    assert members_left[0][0] == as_number
+    assert members_left[0][1] == expected_end_date
+
+
 def test_does_not_mark_member_as_left_if_asn_is_registered_in_country_zz_and_is_assigned(
     faker,
 ):
@@ -72,6 +92,21 @@ def test_marks_member_as_left_if_asn_is_registered_in_country_zz_and_is_not_assi
     )
 
     assert len(members_left) == 1
+
+
+def test_does_not_mark_as112_as_left_if_registered_in_country_zz_and_is_not_assigned(
+    faker,
+):
+    as_number = 112
+    members: dict[int, IXPMemberDetails] = {
+        as_number: create_member_details(faker, last_active=date_now)
+    }
+
+    members_left = check_if_members_have_left(
+        members, date_now, TestLookup(default_country="ZZ", default_status="unassigned")
+    )
+
+    assert len(members_left) == 0
 
 
 def test_does_not_mark_as_left_before_joining_date(faker):


### PR DESCRIPTION
This fixes the two issues we saw in the most recent data re-process:
- AS112 is ignored whenever we check registration country is ZZ,
- if an AS is marked as left due to the ZZ country check, we ignore it on the import (to avoid multiple redundant events)