### PR TITLE
Remove logic to combine memberships

### DIFF
--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -196,44 +196,29 @@ class IXPTracker:
             )
             if member_registered_to_zz_and_has_left_already:
                 continue
+            date_updated = ixpt.stringify_date(member["updated_date"])
             member_has_rejoined = (
-                existing_member
-                and existing_member.date_left is not None
-                and existing_member.date_left < member["created_date"]
+                existing_member and existing_member.date_left is not None
             )
             if existing_member is None or member_has_rejoined:
                 join_event = ixpt.IXPMemberJoined(
                     member["asn"],
-                    ixpt.stringify_date(member["created_date"]),
-                    ixpt.stringify_date(member["updated_date"]),
+                    ixpt.stringify_date(processing_date),
+                    date_updated,
                     ixpt.stringify_date(processing_date),
                     member["is_rs_peer"],
                     member["port_speed"],
                 )
                 ixp = self.es.store(ixp, join_event)
             else:
-                updates: dict[str, Any] = {}
-                # If we already have an inactive member, but it's end_date is after the start_date we're importing,
-                # then we just unset the end_date, which makes the member active and keeps the original start_date
-                if (
-                    existing_member.date_left is not None
-                    and existing_member.date_left > member["created_date"]
-                ):
-                    updates["date_left"] = None
-                elif member["created_date"] != existing_member.date_joined:
-                    updates["date_joined"] = ixpt.stringify_date(member["created_date"])
-                if member["updated_date"] != existing_member.date_updated:
-                    updates["date_updated"] = ixpt.stringify_date(
-                        member["updated_date"]
-                    )
                 if member["port_speed"] != existing_member.port_speed:
-                    updates["port_speed"] = member["port_speed"]
-                if len(updates.keys()) > 0:
-                    update_event = ixpt.IXPMemberUpdated(member["asn"], **updates)
+                    update_event = ixpt.PortSpeedUpdated(
+                        member["asn"], member["port_speed"], date_updated
+                    )
                     ixp = self.es.store(ixp, update_event)
                 if member["is_rs_peer"] != existing_member.is_rs_peer:
                     rs_peer_event = ixpt.RsPeeringStatusChange(
-                        member["asn"], member["is_rs_peer"]
+                        member["asn"], member["is_rs_peer"], date_updated
                     )
                     ixp = self.es.store(ixp, rs_peer_event)
                 active_event = ixpt.IXPMemberActiveInPeeringDb(

--- a/ixp_tracker/ixp_tracker_aggregates.py
+++ b/ixp_tracker/ixp_tracker_aggregates.py
@@ -89,12 +89,10 @@ class IXPMemberJoined(DomainEvent):
 
 
 @dataclass
-class IXPMemberUpdated(DomainEvent):
+class PortSpeedUpdated(DomainEvent):
     asn: int
-    date_joined: str | ValueNotChanged = ValueNotChanged()
-    date_left: str | ValueNotChanged = ValueNotChanged()
-    date_updated: str | ValueNotChanged = ValueNotChanged()
-    port_speed: int | ValueNotChanged = ValueNotChanged()
+    port_speed: int
+    date_updated: str
 
 
 @dataclass
@@ -107,6 +105,7 @@ class IXPMemberActiveInPeeringDb(DomainEvent):
 class RsPeeringStatusChange(DomainEvent):
     asn: int
     is_rs_peer: bool
+    date_updated: str
 
 
 @dataclass
@@ -153,8 +152,8 @@ IXP_TRACKER_EVENT_MAP = {
     IXPMemberActiveInPeeringDb.__name__: IXPMemberActiveInPeeringDb,
     IXPMemberJoined.__name__: IXPMemberJoined,
     IXPMemberLeft.__name__: IXPMemberLeft,
-    IXPMemberUpdated.__name__: IXPMemberUpdated,
     PhysicalLocationChange.__name__: PhysicalLocationChange,
+    PortSpeedUpdated.__name__: PortSpeedUpdated,
     RsPeeringStatusChange.__name__: RsPeeringStatusChange,
 }
 
@@ -316,19 +315,11 @@ class IXP(Aggregate):
         )
         self.members[event.asn] = details
 
-    def member_updated(self, event: IXPMemberUpdated):
-        if not isinstance(event.date_joined, ValueNotChanged):
-            self.members[event.asn].date_joined = datetime.strptime(
-                event.date_joined, DATE_FORMAT
-            )
-        if not isinstance(event.date_updated, ValueNotChanged):
-            self.members[event.asn].date_updated = datetime.strptime(
-                event.date_updated, DATE_FORMAT
-            )
-        if not isinstance(event.port_speed, ValueNotChanged):
-            self.members[event.asn].port_speed = event.port_speed
-        if not isinstance(event.date_left, ValueNotChanged):
-            self.members[event.asn].date_left = None
+    def port_speed_updated(self, event: PortSpeedUpdated):
+        self.members[event.asn].date_updated = datetime.strptime(
+            event.date_updated, DATE_FORMAT
+        )
+        self.members[event.asn].port_speed = event.port_speed
 
     def member_active_in_peering_db(self, event: IXPMemberActiveInPeeringDb):
         self.members[event.asn].last_active = datetime.strptime(

--- a/tests/test_app_member.py
+++ b/tests/test_app_member.py
@@ -24,7 +24,7 @@ from tests.fixtures import (
 
 pytestmark = pytest.mark.django_db
 
-date_now = datetime.now(timezone.utc)
+date_now = datetime.now(timezone.utc).replace(microsecond=0)
 
 
 def test_imports_member(faker: Faker):
@@ -85,10 +85,10 @@ def test_adds_new_membership_for_existing_member_marked_as_left(faker):
     ixp = app.import_members(ixp, [member_import_data], date_now)
 
     updated = ixp.get_members().get(asn.number)
-    assert updated.date_joined > membership_properties["end_date"]
+    assert updated.date_joined == date_now
 
 
-def test_extends_membership_for_member_marked_as_left_if_created_before_date_left(
+def test_adds_new_membership_for_member_marked_as_left_if_created_before_date_left(
     faker,
 ):
     mes = MemoryEventStore()
@@ -109,8 +109,7 @@ def test_extends_membership_for_member_marked_as_left_if_created_before_date_lef
     ixp = app.import_members(ixp, [member_import_data], date_now)
 
     updated = ixp.get_members().get(asn.number)
-    assert updated.date_joined == membership_properties["start_date"]
-    assert updated.date_left is None
+    assert updated.date_joined == date_now
 
 
 def test_ensure_multiple_member_entries_does_not_trigger_multiple_new_memberships(
@@ -143,7 +142,7 @@ def test_ensure_multiple_member_entries_does_not_trigger_multiple_new_membership
     assert len(ixp.get_members()) == 1
 
 
-def test_do_not_add_new_membership_for_same_created_date(faker):
+def test_adds_new_membership_event_if_created_date_is_same(faker):
     created_date = datetime(year=2023, month=1, day=13, tzinfo=timezone.utc)
 
     mes = MemoryEventStore()
@@ -164,7 +163,8 @@ def test_do_not_add_new_membership_for_same_created_date(faker):
 
     ixp = app.import_members(ixp, [member_import], date_now)
 
-    assert len(ixp.get_members()) == 1
+    updated = ixp.get_members().get(asn.number)
+    assert updated.date_joined == date_now
 
 
 def test_marks_ixp_active_if_has_three_members(


### PR DESCRIPTION
The actual change to remove the logic to combine memberships was fairly straightforward but...

I backed out of using "updated" for the membership start dates as there's no guarantee the updates would be applied in order and I think it would really be odd to have events in sequence that had dates out of order.

It meant the `IXPMemberUpdated` event was just notifying of a port speed or "updated" date change. It felt odd to add potential events with just an "updated_date" so I made that event a `PortSpeedUpdated` event. I also added the "updated_date" to the RS peer change event so we're consistently storing that in any member change events (could be handy for analysis after we've run all the historical data again). We can't really add "updated_date" to `IXPMemberLeft` events as in most cases we don't have a PDB record to use for that date.