### PR TITLE
Use current datetime to retrieve AS registration country

### DIFF
--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -46,7 +46,7 @@ def import_data(
         processing_date = datetime.now(timezone.utc)
         import_ixps(processing_date, additional_data, es_app)
         logger.debug("Imported IXPs")
-        import_asns(additional_data, reset, page_limit, es_app)
+        import_asns(processing_date, additional_data, reset, page_limit, es_app)
         logger.debug("Imported ASNs")
         import_members(processing_date, additional_data, es_app)
         logger.debug("Imported members")
@@ -112,7 +112,7 @@ def import_data(
         ixp_data = backfill_data.get("ix", {"data": []}).get("data", [])
         process_ixp_data(processing_date, additional_data, es_app)(ixp_data)
         asn_data = backfill_data.get("net", {"data": []}).get("data", [])
-        process_asn_data(additional_data, es_app)(asn_data)
+        process_asn_data(processing_date, additional_data, es_app)(asn_data)
         member_data = backfill_data.get("netixlan", {"data": []}).get("data", [])
         process_member_data(processing_date, additional_data, es_app)(member_data)
         toggle_ixp_active_status(processing_date, es_app)
@@ -266,6 +266,7 @@ def process_ixp_data(
 
 
 def import_asns(
+    processing_date: datetime,
     geo_lookup: ASNGeoLookup,
     reset: bool = False,
     page_limit: int = 200,
@@ -279,20 +280,22 @@ def import_asns(
             updated_since = last_updated.last_updated
     return get_data(
         "/net",
-        process_asn_data(geo_lookup, es_app),
+        process_asn_data(processing_date, geo_lookup, es_app),
         limit=page_limit,
         last_updated=updated_since,
     )
 
 
-def process_asn_data(geo_lookup, event_sourcing_app: IXPTracker | None = None):
+def process_asn_data(
+    processing_date: datetime, geo_lookup, event_sourcing_app: IXPTracker | None = None
+):
     def process_asn_paged_data(all_asn_data):
         for asn_data in all_asn_data:
             try:
                 asn = int(asn_data["asn"])
                 last_updated = dateutil.parser.isoparse(asn_data["updated"])
-                country_code = geo_lookup.get_iso2_country(asn, last_updated)
                 if event_sourcing_app:
+                    country_code = geo_lookup.get_iso2_country(asn, processing_date)
                     try:
                         network_type = NetworkType(asn_data["info_type"])
                     except ValueError:
@@ -310,6 +313,7 @@ def process_asn_data(geo_lookup, event_sourcing_app: IXPTracker | None = None):
                         country_code,
                     )
                 else:
+                    country_code = geo_lookup.get_iso2_country(asn, last_updated)
                     models.ASN.objects.update_or_create(
                         peeringdb_id=asn_data["id"],
                         defaults={

--- a/tests/test_asns_import.py
+++ b/tests/test_asns_import.py
@@ -11,21 +11,21 @@ from ixp_tracker.models import ASN
 from .fixtures import ASNFactory, PeeringASNFactory
 
 pytestmark = pytest.mark.django_db
+processing_date = datetime.now(timezone.utc)
 
 
 class TestLookup:
-
     def get_iso2_country(self, asn: int, as_at: datetime) -> str:
         assert as_at <= datetime.now(timezone.utc)
         assert asn > 0
         return "AU"
 
     def get_status(self, asn: int, as_at: datetime) -> str:
-        pass
+        return "assigned"
 
 
 def test_with_empty_response_does_nothing():
-    processor = importers.process_asn_data(TestLookup())
+    processor = importers.process_asn_data(processing_date, TestLookup())
     processor([])
 
     asns = ASN.objects.all()
@@ -34,18 +34,15 @@ def test_with_empty_response_does_nothing():
 
 def test_with_no_existing_data_gets_all_data():
     with responses.RequestsMock() as rsps:
-        rsps.get(
-            url=IXP_TRACKER_PEERING_DB_URL + "/net?limit=200&skip=0",
-            body=""
-        )
-        importers.import_asns(TestLookup(), False)
+        rsps.get(url=IXP_TRACKER_PEERING_DB_URL + "/net?limit=200&skip=0", body="")
+        importers.import_asns(processing_date, TestLookup(), False)
 
         asns = ASN.objects.all()
         assert len(asns) == 0
 
 
 def test_imports_new_asn():
-    processor = importers.process_asn_data(TestLookup())
+    processor = importers.process_asn_data(processing_date, TestLookup())
     processor([PeeringASNFactory()])
 
     asns = ASN.objects.all()
@@ -57,18 +54,20 @@ def test_updates_existing_data():
     ASNFactory(
         number=updated_asn_data["asn"],
         peeringdb_id=updated_asn_data["id"],
-        last_updated=datetime(2024, 5, 1, tzinfo=timezone.utc)
+        last_updated=datetime(2024, 5, 1, tzinfo=timezone.utc),
     )
     with responses.RequestsMock() as rsps:
         rsps.get(
-            url=IXP_TRACKER_PEERING_DB_URL + "/net?updated__gte=2024-05-01&limit=200&skip=0",
+            url=IXP_TRACKER_PEERING_DB_URL
+            + "/net?updated__gte=2024-05-01&limit=200&skip=0",
             body=json.dumps({"data": [updated_asn_data]}),
         )
         rsps.get(
-            url=IXP_TRACKER_PEERING_DB_URL + "/net?updated__gte=2024-05-01&limit=200&skip=200",
+            url=IXP_TRACKER_PEERING_DB_URL
+            + "/net?updated__gte=2024-05-01&limit=200&skip=200",
             body=json.dumps({"data": []}),
         )
-        importers.import_asns(TestLookup(), False)
+        importers.import_asns(processing_date, TestLookup(), False)
 
         asns = ASN.objects.all()
         assert len(asns) == 1
@@ -82,7 +81,7 @@ def test_handles_errors_with_source_data():
     data_with_problems["updated"] = "abc"
     data_with_problems["asn"] = "foobar"
 
-    processor = importers.process_asn_data(TestLookup())
+    processor = importers.process_asn_data(processing_date, TestLookup())
     processor([data_with_problems])
 
     asns = ASN.objects.all()

--- a/tests/test_asns_import_es.py
+++ b/tests/test_asns_import_es.py
@@ -1,18 +1,22 @@
+from datetime import datetime, timezone
+
 import pytest
 import responses
 
 from django_test_app.settings import IXP_TRACKER_PEERING_DB_URL
 from ixp_tracker import importers
+from ixp_tracker.data_lookup import ASNGeoLookup
 from ixp_tracker.ixp_tracker_aggregates import NetworkType, PeeringPolicy
 
 from .fixtures import PeeringASNFactory, build_app, TestLookup
 
 pytestmark = pytest.mark.django_db
+processing_date = datetime.now(timezone.utc)
 
 
 def test_with_empty_response_does_nothing():
     app = build_app()
-    processor = importers.process_asn_data(TestLookup(), app)
+    processor = importers.process_asn_data(processing_date, TestLookup(), app)
     processor([])
 
     asns = app.get_all_asns()
@@ -31,7 +35,7 @@ def test_with_no_existing_data_gets_all_data():
 
 def test_imports_new_asn():
     app = build_app()
-    processor = importers.process_asn_data(TestLookup(), app)
+    processor = importers.process_asn_data(processing_date, TestLookup(), app)
     processor([PeeringASNFactory()])
 
     asns = app.get_all_asns()
@@ -40,7 +44,7 @@ def test_imports_new_asn():
 
 def test_uses_defaults_for_network_type_and_peering_policy_if_invalid():
     app = build_app()
-    processor = importers.process_asn_data(TestLookup(), app)
+    processor = importers.process_asn_data(processing_date, TestLookup(), app)
     asn_data = PeeringASNFactory()
     asn_data["info_type"] = "foobar"
     asn_data["policy_general"] = "foobar"
@@ -66,7 +70,9 @@ def test_updates_existing_data(faker):
         faker.country_code(),
     )
 
-    processor = importers.process_asn_data(TestLookup(default_country="AU"), app)
+    processor = importers.process_asn_data(
+        processing_date, TestLookup(default_country="AU"), app
+    )
     processor([updated_asn_data])
 
     asns = app.get_all_asns()
@@ -82,8 +88,47 @@ def test_handles_errors_with_source_data():
     data_with_problems["asn"] = "foobar"
 
     app = build_app()
-    processor = importers.process_asn_data(TestLookup(), app)
+    processor = importers.process_asn_data(processing_date, TestLookup(), app)
     processor([data_with_problems])
 
     asns = app.get_all_asns()
     assert len(asns) == 0
+
+
+def test_uses_registration_country_at_processing_date():
+    updated_date = processing_date.replace(year=(processing_date.year - 1))
+
+    class DateSensitiveLookup(ASNGeoLookup):
+        __test__ = False
+
+        def __init__(
+            self, default_status: str = "assigned", default_country: str = "US"
+        ):
+            self.default_status = default_status
+            self.default_country = default_country
+
+        def get_iso2_country(self, asn: int, as_at: datetime) -> str:
+            if as_at.year == updated_date.year:
+                return "FR"
+            return self.default_country
+
+        def get_status(self, asn: int, as_at: datetime) -> str:
+            assert as_at <= datetime.now(timezone.utc)
+            assert asn > 0
+            return self.default_status
+
+        def get_asns_for_country(self, country: str, as_at: datetime) -> list[int]:
+            return []
+
+        def get_routed_asns_for_country(
+            self, country: str, as_at: datetime
+        ) -> list[int]:
+            return []
+
+    app = build_app()
+    processor = importers.process_asn_data(processing_date, DateSensitiveLookup(), app)
+    processor([PeeringASNFactory(updated_date=updated_date)])
+
+    asns = app.get_all_asns()
+    asn_added = asns[0]
+    assert asn_added.country_code == "US"


### PR DESCRIPTION
Most of this is boilerplate as we now need to pass the `processing_date` into the ASN importing functions.