### PR TITLE
Use time travel

### DIFF
--- a/ixp_tracker/event_store.py
+++ b/ixp_tracker/event_store.py
@@ -92,12 +92,18 @@ class EventStorePersistence(ABC):
 
     @abstractmethod
     def get_aggregate_events(
-        self, aggregate_id: UUID, aggregate_type: type[T], sequence: int | None
+        self,
+        aggregate_id: UUID,
+        aggregate_type: type[T],
+        sequence: int | None,
+        as_at: datetime | None = None,
     ) -> list[StoredEvent]:
         pass
 
     @abstractmethod
-    def get_all(self, aggregate_type: type[T]) -> list[UUID]:
+    def get_all(
+        self, aggregate_type: type[T], as_at: datetime | None = None
+    ) -> list[UUID]:
         pass
 
     @abstractmethod
@@ -111,7 +117,9 @@ class EventStorePersistence(ABC):
         pass
 
     @abstractmethod
-    def load_snapshot(self, aggregate_id: UUID) -> tuple[dict, int] | tuple[None, None]:
+    def load_snapshot(
+        self, aggregate_id: UUID, as_at: datetime | None = None
+    ) -> tuple[dict, int] | tuple[None, None]:
         pass
 
 
@@ -122,7 +130,7 @@ class EventStore:
         self.db: EventStorePersistence = db
         self.date_now: datetime | None = None
 
-    def time_travel(self, date_in_past: datetime):
+    def time_travel(self, date_in_past: datetime | None):
         self.date_now = date_in_past
 
     def store(self, aggregate: T, event: DomainEvent) -> T:
@@ -151,12 +159,16 @@ class EventStore:
 
         return aggregate
 
-    def get_aggregate(self, aggregate_id: UUID, aggregate_type: type[T]) -> T:
-        data, sequence = self.db.load_snapshot(aggregate_id)
+    def get_aggregate(
+        self, aggregate_id: UUID, aggregate_type: type[T], as_at: datetime | None = None
+    ) -> T:
+        data, sequence = self.db.load_snapshot(aggregate_id, as_at)
         aggregate = aggregate_type(aggregate_id)
         if data:
             aggregate.hydrate(data)
-        events = self.db.get_aggregate_events(aggregate_id, aggregate_type, sequence)
+        events = self.db.get_aggregate_events(
+            aggregate_id, aggregate_type, sequence, as_at
+        )
         if sequence is None and len(events) == 0:
             raise AggregateNotFound
         for event in events:
@@ -173,11 +185,13 @@ class EventStore:
             )
         return aggregate
 
-    def get_all(self, aggregate_type: type[T]) -> list[T]:
-        aggregate_ids = self.db.get_all(aggregate_type)
+    def get_all(
+        self, aggregate_type: type[T], as_at: datetime | None = None
+    ) -> list[T]:
+        aggregate_ids = self.db.get_all(aggregate_type, as_at)
         aggregates = []
         for aggregate_id in aggregate_ids:
-            aggregates.append(self.get_aggregate(aggregate_id, aggregate_type))
+            aggregates.append(self.get_aggregate(aggregate_id, aggregate_type, as_at))
         return aggregates
 
     def add_listener(self, projection: Projection):
@@ -213,29 +227,28 @@ class DjangoEventStore(EventStorePersistence):
         event.save()
 
     def get_aggregate_events(
-        self, aggregate_id: UUID, aggregate_type: type[T], sequence: int | None
+        self,
+        aggregate_id: UUID,
+        aggregate_type: type[T],
+        sequence: int | None,
+        as_at: datetime | None = None,
     ):
-        if sequence is None:
-            return (
-                StoredEvent.objects.filter(aggregate_id=aggregate_id)
-                .order_by("event_sequence")
-                .all()
-            )
-        else:
-            return (
-                StoredEvent.objects.filter(
-                    aggregate_id=aggregate_id, event_sequence__gt=sequence
-                )
-                .order_by("event_sequence")
-                .all()
-            )
+        events = StoredEvent.objects.filter(aggregate_id=aggregate_id)
+        if sequence is not None:
+            events = events.filter(event_sequence__gt=sequence)
+        if as_at is not None:
+            events = events.filter(event_date__lte=as_at)
+        return events.order_by("event_sequence").all()
 
-    def get_all(self, aggregate_type: type[T]) -> list[UUID]:
-        return list(
-            StoredEvent.objects.filter(aggregate_type=aggregate_type.__name__)
-            .values_list("aggregate_id", flat=True)
-            .distinct()
+    def get_all(
+        self, aggregate_type: type[T], as_at: datetime | None = None
+    ) -> list[UUID]:
+        aggregate_ids = StoredEvent.objects.filter(
+            aggregate_type=aggregate_type.__name__
         )
+        if as_at is not None:
+            aggregate_ids = aggregate_ids.filter(event_date__lte=as_at)
+        return list(aggregate_ids.values_list("aggregate_id", flat=True).distinct())
 
     def get_events(self) -> list[StoredEvent]:
         return list(StoredEvent.objects.all())
@@ -249,8 +262,13 @@ class DjangoEventStore(EventStorePersistence):
             defaults={"data": data, "snapshot_date": date_now},
         )
 
-    def load_snapshot(self, aggregate_id: UUID) -> tuple[dict, int] | tuple[None, None]:
-        snapshot = AggregateSnapshot.objects.filter(aggregate_id=aggregate_id).first()
+    def load_snapshot(
+        self, aggregate_id: UUID, as_at: datetime | None = None
+    ) -> tuple[dict, int] | tuple[None, None]:
+        snapshots = AggregateSnapshot.objects.filter(aggregate_id=aggregate_id)
+        if as_at is not None:
+            snapshots = snapshots.filter(snapshot_date__lte=as_at)
+        snapshot = snapshots.first()
         if snapshot is None:
             return None, None
         else:

--- a/ixp_tracker/importers.py
+++ b/ixp_tracker/importers.py
@@ -42,9 +42,14 @@ def import_data(
     processing_date: datetime | None = None,
     page_limit: int = 200,
 ):
-    es_app = build_app(additional_data)
     if processing_date is None:
+        backfill = False
         processing_date = datetime.now(timezone.utc)
+    else:
+        backfill = True
+        processing_date = processing_date.replace(day=1)
+    es_app = build_app(additional_data, processing_date)
+    if not backfill:
         import_ixps(processing_date, additional_data, es_app)
         logger.debug("Imported IXPs")
         import_asns(processing_date, additional_data, reset, page_limit, es_app)
@@ -54,9 +59,6 @@ def import_data(
         toggle_ixp_active_status(processing_date, es_app)
         logger.debug("Toggled IXPs active status")
     else:
-        processing_date = processing_date.replace(day=1)
-        if es_app:
-            es_app.time_travel(processing_date)
         processing_month = processing_date.month
         found = False
         backfill_raw = None
@@ -167,13 +169,16 @@ def import_ixps(
     )
 
 
-def build_app(geo_lookup: ASNGeoLookup) -> IXPTracker | None:
+def build_app(geo_lookup: ASNGeoLookup, processing_date: datetime) -> IXPTracker | None:
     if not IXP_TRACKER_ENABLE_EVENT_SOURCING:
         return None
     es = EventStore(IXP_TRACKER_EVENT_MAP, DjangoEventStore())
     es.add_listener(IXPIdMapProjection())
     es.add_listener(ASNList())
     app = IXPTracker(es, geo_lookup)
+    # We always set the time travel so the monthly stats can run safely for the first of each month,
+    # and we set the time elements to zero to ensure we always get all events for that date
+    app.time_travel(processing_date.replace(hour=0, minute=0, second=0, microsecond=0))
     return app
 
 

--- a/ixp_tracker/ixp_tracker.py
+++ b/ixp_tracker/ixp_tracker.py
@@ -273,8 +273,8 @@ class IXPTracker:
         except IXPIdMap.DoesNotExist:
             return None
 
-    def get_all_ixps(self):
-        return self.es.get_all(ixpt.IXP)
+    def get_all_ixps(self, as_at: datetime | None = None):
+        return self.es.get_all(ixpt.IXP, as_at)
 
     def get_all_asns(self):
         return self.es.get_all(ixpt.ASN)

--- a/ixp_tracker/stats.py
+++ b/ixp_tracker/stats.py
@@ -31,7 +31,8 @@ class CountryStats(TypedDict):
 
 
 def generate_stats(lookup: AdditionalDataSources, stats_date: datetime | None = None):
-    es_app = build_app(lookup)
+    stats_date = stats_date or datetime.now(timezone.utc)
+    es_app = build_app(lookup, stats_date)
     do_generate_stats(lookup, stats_date, es_app)
 
 
@@ -262,13 +263,12 @@ def do_generate_stats(
                 },
             )
     else:
-        ixps = es_app.get_all_ixps()
+        # Ensure we load the state of all IXPs as they were on the stats date
+        ixps = es_app.get_all_ixps(stats_date)
         for ixp in ixps:
             # We always save the stats per IXP after their created date so we can track stats across time (e.g. if an IXP becomes inactive then active again)
-            if ixp.date_created > stats_date:
-                continue
             isoc_id = es_app.find_isoc_id(ixp.id)
-            members = ixp.get_members(as_at=stats_date)
+            members = ixp.get_members()
             member_asns = list(members.keys())
             member_count = len(member_asns)
             total_capacity = sum([m.port_speed for m in members.values()])
@@ -320,8 +320,7 @@ def do_generate_stats(
                     "IXP has possible invalid country",
                     extra={"ixp": isoc_id, "country": ixp.country_code},
                 )
-            # ixp.active_status only gives us the current active state, we need the historical state so we check the member list directly
-            if is_ixp_active(member_asns):
+            if ixp.active_status:
                 all_stats_per_country[ixp.country_code]["ixp_count"] += 1
                 all_stats_per_country[ixp.country_code]["member_asns"] |= set(
                     member_asns

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -463,19 +463,28 @@ class MemoryEventStore(EventStorePersistence):
         self.events.append(event)
 
     def get_aggregate_events(
-        self, aggregate_id: UUID, aggregate_type: type[T], sequence: int | None
+        self,
+        aggregate_id: UUID,
+        aggregate_type: type[T],
+        sequence: int | None,
+        as_at: datetime | None = None,
     ) -> list[StoredEvent]:
         events = [e for e in self.events if e.aggregate_id == aggregate_id]
-        if sequence is None:
-            return events
-        return [e for e in events if e.event_sequence > sequence]
+        if sequence is not None:
+            events = [e for e in events if e.event_sequence > sequence]
+        if as_at is not None:
+            events = [e for e in events if e.event_date <= as_at]
+        return events
 
-    def get_all(self, aggregate_type: type[T]) -> list[UUID]:
+    def get_all(
+        self, aggregate_type: type[T], as_at: datetime | None = None
+    ) -> list[UUID]:
         aggregates = set(
             [
                 e.aggregate_id
                 for e in self.events
                 if e.aggregate_type == aggregate_type.__name__
+                and (as_at is None or e.event_date <= as_at)
             ]
         )
         return list(aggregates)
@@ -488,7 +497,9 @@ class MemoryEventStore(EventStorePersistence):
     ):
         self.snapshots[aggregate_id] = (json.dumps(data), sequence, date_now)
 
-    def load_snapshot(self, aggregate_id: UUID) -> tuple[dict, int] | tuple[None, None]:
+    def load_snapshot(
+        self, aggregate_id: UUID, as_at: datetime | None = None
+    ) -> tuple[dict, int] | tuple[None, None]:
         snapshot = self.snapshots.get(aggregate_id, None)
         if snapshot is None:
             return None, None

--- a/tests/test_country_stats_es.py
+++ b/tests/test_country_stats_es.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from factory import Faker
+from faker import Faker
 
 from ixp_tracker.ixp_tracker_projections import ASNList, IXPIdMapProjection
 
@@ -40,6 +40,7 @@ def test_with_no_data_generates_no_stats():
 
 def test_generates_stats(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    es.time_travel(created_date)
     ixp_one = create_ixp(faker, es, created_date=created_date, active_status=True)
     create_member(
         faker, es, ixp_one, create_asn(faker, es), {"start_date": created_date}
@@ -98,47 +99,15 @@ def test_generates_ixp_counts(faker: Faker):
     stats_date = datetime.now(timezone.utc)
     one_month_before = (stats_date - timedelta(days=1)).replace(day=1)
     one_month_after = (stats_date + timedelta(days=35)).replace(day=1)
-    # active_status only stores the current status whereas the stats need to generate historically
-    # so the stats use the historical member count rather than active_status
-    # currently_active with three members
-    active = create_ixp(faker, es, created_date=created_date, active_status=True)
-    create_member(
-        faker,
-        es,
-        active,
-        create_asn(faker, es),
-        {
-            "start_date": one_month_before,
-            "end_date": one_month_after,
-        },
-    )
-    create_member(
-        faker,
-        es,
-        active,
-        create_asn(faker, es),
-        {
-            "start_date": one_month_before,
-            "end_date": one_month_after,
-        },
-    )
-    create_member(
-        faker,
-        es,
-        active,
-        create_asn(faker, es),
-        {
-            "start_date": one_month_before,
-            "end_date": one_month_after,
-        },
-    )
+    country_code = faker.country_code()
     # member active in the past
+    es.time_travel(one_month_before)
     member_in_past = create_ixp(
         faker,
         es,
-        created_date=created_date,
-        active_status=True,
-        country_code=active.country_code,
+        created_date=one_month_before,
+        active_status=False,
+        country_code=country_code,
     )
     create_member(
         faker,
@@ -150,28 +119,49 @@ def test_generates_ixp_counts(faker: Faker):
             "end_date": one_month_before,
         },
     )
-    # member not yet active (as we are generating historical stats there could be members in the future)
-    member_in_future = create_ixp(
+    # IXP with three currently active members
+    es.time_travel(created_date)
+    active = create_ixp(
         faker,
         es,
         created_date=created_date,
         active_status=True,
-        country_code=active.country_code,
+        country_code=country_code,
     )
     create_member(
         faker,
         es,
-        member_in_future,
+        active,
         create_asn(faker, es),
-        {"start_date": one_month_after},
+        {
+            "start_date": one_month_before,
+        },
+    )
+    create_member(
+        faker,
+        es,
+        active,
+        create_asn(faker, es),
+        {
+            "start_date": one_month_before,
+        },
+    )
+    create_member(
+        faker,
+        es,
+        active,
+        create_asn(faker, es),
+        {
+            "start_date": one_month_before,
+        },
     )
     # currently_active but only two members
     not_enough_members = create_ixp(
         faker,
         es,
         created_date=created_date,
-        active_status=True,
-        country_code=active.country_code,
+        active_status=False,
+        country_code=country_code,
     )
     create_member(
         faker,
@@ -180,9 +170,39 @@ def test_generates_ixp_counts(faker: Faker):
         create_asn(faker, es),
         {
             "start_date": one_month_before,
-            "end_date": one_month_after,
         },
     )
+    # IXP created but members not yet active (as we are generating historical stats there could be members in the future)
+    member_in_future = create_ixp(
+        faker,
+        es,
+        created_date=created_date,
+        active_status=False,
+        country_code=country_code,
+    )
+    es.time_travel(one_month_after)
+    create_member(
+        faker,
+        es,
+        member_in_future,
+        create_asn(faker, es),
+        {"start_date": one_month_after},
+    )
+    create_member(
+        faker,
+        es,
+        member_in_future,
+        create_asn(faker, es),
+        {"start_date": one_month_after},
+    )
+    create_member(
+        faker,
+        es,
+        member_in_future,
+        create_asn(faker, es),
+        {"start_date": one_month_after},
+    )
+
     do_generate_stats(MockLookup(), stats_date, es_app=app)
 
     stats = StatsPerCountryES.objects.filter(country_code=active.country_code).first()

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
-from datetime import timezone, datetime
+from datetime import timezone, datetime, timedelta
 
 import pytest
 
 from uuid import uuid4
+
+from faker import Faker
 
 from ixp_tracker.event_store import (
     DjangoEventStore,
@@ -205,3 +207,29 @@ def test_time_machine_saves_event_in_the_past(faker):
 
     stored_event = des.get_events().pop()
     assert stored_event.event_date == time_in_past
+
+
+def test_retrieves_past_state_of_aggregate(faker: Faker):
+    des = DjangoEventStore()
+    es = EventStore(TEST_EVENT_MAP, des)
+    time_in_past = faker.date_time_between(
+        start_date="-2w", end_date="-1w", tzinfo=timezone.utc
+    )
+
+    # Create an aggregate in the past using time travel
+    es.time_travel(time_in_past)
+    aggregate = TestAggregate(id=uuid4())
+    create_event = CreatedTestAggregate(foo="bar")
+    es.store(aggregate, create_event)
+
+    # Update the aggregate in real time
+    es.time_travel(None)
+    update_event = TestAggregateUpdated(foo="baz")
+    es.store(aggregate, update_event)
+
+    time_before_update = datetime.now(timezone.utc) - timedelta(days=1)
+    aggregate_in_past = es.get_aggregate(
+        aggregate.id, TestAggregate, time_before_update
+    )
+
+    assert aggregate_in_past.foo == "bar"

--- a/tests/test_ixp_stats_es.py
+++ b/tests/test_ixp_stats_es.py
@@ -29,7 +29,8 @@ from tests.fixtures import (
 
 pytestmark = pytest.mark.django_db
 # Ensure default created date is before 1st of current month so it's counted in the stats
-created_date = datetime.now(timezone.utc).replace(day=1) - timedelta(days=7)
+start_of_current_month = datetime.now(timezone.utc).replace(day=1)
+created_date = start_of_current_month - timedelta(days=7)
 
 
 def test_with_no_data_generates_no_stats():
@@ -42,6 +43,7 @@ def test_with_no_data_generates_no_stats():
 
 def test_generates_capacity_rs_peering_and_member_count(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    es.time_travel(start_of_current_month)
     ixp = create_ixp(faker, es, created_date=created_date)
     asn_one = create_asn(faker, es)
     create_member(
@@ -72,9 +74,10 @@ def test_generates_capacity_rs_peering_and_member_count(faker: Faker):
 
 def test_generates_stats_for_first_of_month(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    stats_date = datetime.now(timezone.utc).replace(day=10)
+    es.time_travel(stats_date.replace(day=1))
     create_ixp(faker, es, created_date=created_date)
 
-    stats_date = datetime.now(timezone.utc).replace(day=10)
     do_generate_stats(MockLookup(), stats_date, es_app=app)
 
     stats = StatsPerIXPES.objects.all()
@@ -85,6 +88,7 @@ def test_generates_stats_for_first_of_month(faker: Faker):
 
 def test_does_not_count_members_marked_as_left(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    es.time_travel(start_of_current_month)
     ixp = create_ixp(faker, es, created_date=created_date)
     asn_one = create_asn(faker, es)
     create_member(
@@ -118,6 +122,7 @@ def test_does_not_count_members_marked_as_left(faker: Faker):
 
 def test_does_not_count_member_twice_if_they_rejoin(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    es.time_travel(start_of_current_month)
     ixp = create_ixp(faker, es, created_date=created_date)
     asn = create_asn(faker, es)
     date_left = datetime(year=2024, month=4, day=1, tzinfo=timezone.utc)
@@ -144,6 +149,7 @@ def test_does_not_count_member_twice_if_they_rejoin(faker: Faker):
 def test_does_not_count_members_not_yet_created(faker: Faker):
     app, es = build_app(MemoryEventStore())
     stats_date = datetime(year=2024, month=2, day=1, tzinfo=timezone.utc)
+    es.time_travel(stats_date)
     ixp = create_ixp(faker, es, created_date=stats_date)
     asn = create_asn(faker, es)
     date_joined = stats_date + timedelta(weeks=1)
@@ -159,10 +165,11 @@ def test_does_not_count_members_not_yet_created(faker: Faker):
 def test_does_not_count_ixps_not_yet_created(faker: Faker):
     app, es = build_app(MemoryEventStore())
     stats_date = datetime(year=2024, month=2, day=1, tzinfo=timezone.utc)
-    created_date = stats_date + timedelta(weeks=1)
-    ixp = create_ixp(faker, es, created_date=created_date)
+    ixp_created_date = stats_date + timedelta(weeks=1)
+    es.time_travel(created_date)
+    ixp = create_ixp(faker, es, created_date=ixp_created_date)
     asn = create_asn(faker, es)
-    create_member(faker, es, ixp, asn, {"start_date": created_date})
+    create_member(faker, es, ixp, asn, {"start_date": ixp_created_date})
 
     do_generate_stats(MockLookup(), stats_date, es_app=app)
 
@@ -172,6 +179,7 @@ def test_does_not_count_ixps_not_yet_created(faker: Faker):
 
 def test_saves_domestic_network_membership_rate(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    es.time_travel(start_of_current_month)
     ixp = create_ixp(faker, es, created_date=created_date)
     # IXP has 2 members, one "local" and one not
     local_asn = create_asn(faker, es)
@@ -195,6 +203,7 @@ def test_saves_domestic_network_membership_rate(faker: Faker):
 def test_counts_net_joins_and_net_leaves_since_12_months(faker: Faker):
     app, es = build_app(MemoryEventStore())
     stats_date = datetime(year=2024, month=2, day=1, tzinfo=timezone.utc)
+    es.time_travel(stats_date)
     ixp = create_ixp(faker, es, created_date=stats_date)
     # One member joined more than 12 months ago and is still a member (i.e. not counted in either)
     create_member(
@@ -264,6 +273,7 @@ def test_counts_net_joins_and_net_leaves_since_12_months(faker: Faker):
 def test_adds_member_growth_stats(faker: Faker):
     app, es = build_app(MemoryEventStore())
     stats_date = datetime(year=2025, month=3, day=1, tzinfo=timezone.utc)
+    es.time_travel(stats_date)
     ixp = create_ixp(faker, es, created_date=stats_date)
     # Has 5 current members
     # 4 joined in the past
@@ -293,6 +303,7 @@ def test_adds_member_growth_stats(faker: Faker):
 
 def test_saves_local_routed_asns_members_and_customers_rate(faker: Faker):
     app, es = build_app(MemoryEventStore())
+    es.time_travel(start_of_current_month)
     ixp = create_ixp(faker, es, created_date=created_date)
     local_asn = create_asn(faker, es)
     create_member(faker, es, ixp, local_asn, {"start_date": created_date})
@@ -319,6 +330,7 @@ def test_updates_existing_stats(faker: Faker):
     date_now = datetime.now(timezone.utc)
     # Ensure stats_date and last_generated are always in the past so we can verify the updated last_generated
     stats_date = (date_now.replace(day=1) - timedelta(days=1)).replace(day=1)
+    es.time_travel(stats_date)
     last_generated = stats_date + timedelta(days=1)
     ixp = create_ixp(faker, es, created_date=stats_date)
     create_member(faker, es, ixp, create_asn(faker, es), {"start_date": stats_date})


### PR DESCRIPTION
I had to use the time travel in the tests to recreate the proper state (e.g. ensure `event_date` was always correct) so we could query safely using the date.