### PR TITLE
Tidy up

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -35,7 +35,11 @@ from ixp_tracker.ixp_tracker_aggregates import (
     PeeringPolicy,
     stringify_date,
 )
-from ixp_tracker.ixp_tracker_projections import ASNList, IXPIdMapProjection
+from ixp_tracker.ixp_tracker_projections import (
+    ASNList,
+    IXPIdMapProjection,
+    IXPsLastUpdatedProjection,
+)
 import ixp_tracker.models as legacy
 from ixp_tracker.models import (
     StatsPerCountry,
@@ -259,23 +263,29 @@ class StatsPerIXPFactory(factory.django.DjangoModelFactory):
 class MockLookup(AdditionalDataSources):
     def __init__(
         self,
-        asns: list[int] = [],
-        routed_asns: list[int] = [],
-        customer_asns: list[int] = [],
-        manrs_participants: list[int] = [],
-        anchor_hosts: list[int] = [],
+        asns: list[int] | None = None,
+        routed_asns: list[int] | None = None,
+        customer_asns: list[int] | None = None,
+        manrs_participants: list[int] | None = None,
+        anchor_hosts: list[int] | None = None,
+        default_country: str = "US",
+        default_status: str = "assigned",
     ):
-        self.asns = asns
-        self.routed_asns = routed_asns
-        self.customer_asns = customer_asns
-        self.manrs_participants = manrs_participants
-        self.anchor_hosts = anchor_hosts
+        self.asns = asns or []
+        self.routed_asns = routed_asns or []
+        self.customer_asns = customer_asns or []
+        self.manrs_participants = manrs_participants or []
+        self.anchor_hosts = anchor_hosts or []
+        self.default_country = default_country
+        self.default_status = default_status
 
     def get_iso2_country(self, asn: int, as_at: datetime) -> str:
-        return ""
+        return self.default_country
 
     def get_status(self, asn: int, as_at: datetime) -> str:
-        return ""
+        assert as_at <= datetime.now(timezone.utc)
+        assert asn > 0
+        return self.default_status
 
     def get_asns_for_country(self, country: str, as_at: datetime) -> list[int]:
         return self.asns
@@ -508,12 +518,16 @@ class MemoryEventStore(EventStorePersistence):
         return json.loads(snapshot[0]), snapshot[1]
 
 
-def build_app() -> IXPTracker:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, DjangoEventStore())
-    es.add_listener(ASNList())
+def build_app(
+    es_db: EventStorePersistence | None = None,
+    lookup: AdditionalDataSources | None = None,
+) -> tuple[IXPTracker, EventStore]:
+    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
     es.add_listener(IXPIdMapProjection())
-    app = IXPTracker(es, TestLookup())
-    return app
+    es.add_listener(ASNList())
+    es.add_listener(IXPsLastUpdatedProjection())
+    app = IXPTracker(es, lookup or MockLookup())
+    return app, es
 
 
 def create_ixp_event(
@@ -618,42 +632,3 @@ def create_member(
         )
         ixp = es.store(ixp, left_event)
     return ixp
-
-
-class TestLookup(AdditionalDataSources):
-    __test__ = False
-
-    def __init__(
-        self,
-        default_status: str = "assigned",
-        default_country: str = "US",
-        routed_asns: list[int] | None = None,
-        customer_asns: list[int] | None = None,
-    ):
-        self.default_status = default_status
-        self.default_country = default_country
-        self.routed_asns = routed_asns or []
-        self.customer_asns = customer_asns or []
-
-    def get_iso2_country(self, asn: int, as_at: datetime) -> str:
-        return self.default_country
-
-    def get_status(self, asn: int, as_at: datetime) -> str:
-        assert as_at <= datetime.now(timezone.utc)
-        assert asn > 0
-        return self.default_status
-
-    def get_asns_for_country(self, country: str, as_at: datetime) -> list[int]:
-        return []
-
-    def get_routed_asns_for_country(self, country: str, as_at: datetime) -> list[int]:
-        return self.routed_asns
-
-    def get_customer_asns(self, asns: list[int], as_at: datetime) -> list[int]:
-        return self.customer_asns
-
-    def get_manrs_participants(self, as_at: datetime) -> list[int]:
-        return []
-
-    def get_atlas_anchor_hosts(self, as_at: datetime) -> list[int]:
-        return []

--- a/tests/test_app_asn.py
+++ b/tests/test_app_asn.py
@@ -1,21 +1,11 @@
 import pytest
 from faker.proxy import Faker
 
-from ixp_tracker.event_store import (
-    DjangoEventStore,
-    EventStore,
-    EventStorePersistence,
-)
-from ixp_tracker.ixp_tracker import (
-    IXPTracker,
-)
 from ixp_tracker.ixp_tracker_aggregates import (
-    IXP_TRACKER_EVENT_MAP,
     NetworkType,
     PeeringPolicy,
 )
-from ixp_tracker.ixp_tracker_projections import ASNList
-from tests.fixtures import create_asn, MemoryEventStore, TestLookup
+from tests.fixtures import create_asn, MemoryEventStore, build_app
 
 pytestmark = pytest.mark.django_db
 
@@ -123,12 +113,3 @@ def test_records_peeringdb_id_change_as_separate_event(faker):
     [_event_created, update_event] = mes.events
 
     assert update_event.event_type == "ASNPeeringDbIdChanged"
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(ASNList())
-    app = IXPTracker(es, TestLookup())
-    return app, es

--- a/tests/test_app_ixp.py
+++ b/tests/test_app_ixp.py
@@ -3,17 +3,7 @@ from datetime import timezone
 import pytest
 from faker.proxy import Faker
 
-from ixp_tracker.event_store import (
-    DjangoEventStore,
-    EventStore,
-    EventStorePersistence,
-)
-from ixp_tracker.ixp_tracker import (
-    IXPTracker,
-)
-from ixp_tracker.ixp_tracker_aggregates import IXP_TRACKER_EVENT_MAP
-from ixp_tracker.ixp_tracker_projections import IXPIdMapProjection
-from tests.fixtures import create_ixp, MemoryEventStore, TestLookup
+from tests.fixtures import create_ixp, MemoryEventStore, build_app
 
 pytestmark = pytest.mark.django_db
 
@@ -254,12 +244,3 @@ def test_registers_no_change_in_location_count_if_new_value_is_none(faker):
     assert event_created.event_type == "IXPCreated"
     assert last_active.event_type == "IXPActiveInPeeringDb"
     assert ixp.physical_locations == original_value
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(IXPIdMapProjection())
-    app = IXPTracker(es, TestLookup())
-    return app, es

--- a/tests/test_app_member.py
+++ b/tests/test_app_member.py
@@ -2,24 +2,16 @@ from datetime import datetime, timezone
 import pytest
 from faker import Faker
 
-from ixp_tracker.data_lookup import ASNGeoLookup
-from ixp_tracker.event_store import (
-    EventStorePersistence,
-    EventStore,
-    DjangoEventStore,
-)
 from ixp_tracker.ixp_tracker import (
-    IXPTracker,
     MemberImportData,
 )
-from ixp_tracker.ixp_tracker_aggregates import IXP_TRACKER_EVENT_MAP
-from ixp_tracker.ixp_tracker_projections import ASNList, IXPIdMapProjection
 from tests.fixtures import (
     create_ixp,
     create_asn,
     MemoryEventStore,
     create_member,
-    TestLookup,
+    MockLookup,
+    build_app,
 )
 
 pytestmark = pytest.mark.django_db
@@ -216,7 +208,7 @@ def test_marks_ixp_inactive_if_members_drops_below_three(
 def test_member_marked_left_due_to_zz_country_registration_is_not_imported(faker):
     mes = MemoryEventStore()
     app, es = build_app(
-        mes, TestLookup(default_country="ZZ", default_status="reserved")
+        mes, MockLookup(default_country="ZZ", default_status="reserved")
     )
     ixp = create_ixp(faker, es)
     asn = create_asn(faker, es)
@@ -243,7 +235,7 @@ def test_as112_is_marked_as_rejoined(faker):
     # But we want AS112 to be considered in this case as it probably means it has left and rejoined
     mes = MemoryEventStore()
     app, es = build_app(
-        mes, TestLookup(default_country="ZZ", default_status="reserved")
+        mes, MockLookup(default_country="ZZ", default_status="reserved")
     )
     ixp = create_ixp(faker, es)
     asn = create_asn(faker, es, asn=112)
@@ -257,17 +249,6 @@ def test_as112_is_marked_as_rejoined(faker):
 
     updated_member = ixp.get_members(True)[asn.number]
     assert updated_member.date_left is None
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-    geo_lookup: ASNGeoLookup | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(IXPIdMapProjection())
-    es.add_listener(ASNList())
-    app = IXPTracker(es, geo_lookup or TestLookup(default_country="US"))
-    return app, es
 
 
 def create_member_import_data(

--- a/tests/test_as_zz_country_check.py
+++ b/tests/test_as_zz_country_check.py
@@ -1,14 +1,14 @@
 from datetime import timezone
 
 from ixp_tracker.ixp_tracker import as_zz_country_check
-from tests.fixtures import TestLookup
+from tests.fixtures import MockLookup
 
 
 def test_as_not_registered_to_zz_returns_false(faker):
     asn = faker.random_number(digits=5)
     as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
 
-    assert as_zz_country_check(asn, as_at, TestLookup(default_country="US")) is False
+    assert as_zz_country_check(asn, as_at, MockLookup(default_country="US")) is False
 
 
 def test_as_registered_to_zz_and_not_assigned_returns_true(faker):
@@ -16,7 +16,7 @@ def test_as_registered_to_zz_and_not_assigned_returns_true(faker):
     as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
 
     assert as_zz_country_check(
-        asn, as_at, TestLookup(default_country="ZZ", default_status="reserved")
+        asn, as_at, MockLookup(default_country="ZZ", default_status="reserved")
     )
 
 
@@ -26,7 +26,7 @@ def test_as_registered_to_zz_but_assigned_returns_false(faker):
 
     assert (
         as_zz_country_check(
-            asn, as_at, TestLookup(default_country="ZZ", default_status="assigned")
+            asn, as_at, MockLookup(default_country="ZZ", default_status="assigned")
         )
         is False
     )
@@ -36,4 +36,4 @@ def test_as112_returns_false(faker):
     asn = 112
     as_at = faker.date_time_between(start_date="-1d", tzinfo=timezone.utc)
 
-    assert as_zz_country_check(asn, as_at, TestLookup(default_country="ZZ")) is False
+    assert as_zz_country_check(asn, as_at, MockLookup(default_country="ZZ")) is False

--- a/tests/test_asns_import_es.py
+++ b/tests/test_asns_import_es.py
@@ -8,15 +8,15 @@ from django_test_app.settings import IXP_TRACKER_PEERING_DB_URL
 from ixp_tracker import importers
 from ixp_tracker.ixp_tracker_aggregates import NetworkType, PeeringPolicy
 
-from .fixtures import PeeringASNFactory, build_app, TestLookup
+from .fixtures import PeeringASNFactory, build_app, MockLookup
 
 pytestmark = pytest.mark.django_db
 processing_date = datetime.now(timezone.utc)
 
 
 def test_with_empty_response_does_nothing():
-    app = build_app()
-    processor = importers.process_asn_data(processing_date, TestLookup(), app)
+    app, _ = build_app()
+    processor = importers.process_asn_data(processing_date, MockLookup(), app)
     processor([])
 
     asns = app.get_all_asns()
@@ -25,23 +25,23 @@ def test_with_empty_response_does_nothing():
 
 def test_with_no_existing_data_gets_all_data():
     with responses.RequestsMock() as rsps:
-        app = build_app()
+        app, _ = build_app()
         rsps.get(url=IXP_TRACKER_PEERING_DB_URL + "/net?limit=200&skip=0", body="")
-        importers.import_asns(processing_date, TestLookup(), False, es_app=app)
+        importers.import_asns(processing_date, MockLookup(), False, es_app=app)
 
         asns = app.get_all_asns()
         assert len(asns) == 0
 
 
 def test_imports_new_asn(faker: Faker):
-    app = build_app()
+    app, _ = build_app()
     data_to_import = PeeringASNFactory()
     customer_asns = faker.pylist(
         nb_elements=10, variable_nb_elements=True, value_types=[int]
     )
     processor = importers.process_asn_data(
         processing_date,
-        TestLookup(routed_asns=[data_to_import["asn"]], customer_asns=customer_asns),
+        MockLookup(routed_asns=[data_to_import["asn"]], customer_asns=customer_asns),
         app,
     )
     processor([data_to_import])
@@ -54,8 +54,8 @@ def test_imports_new_asn(faker: Faker):
 
 
 def test_uses_defaults_for_network_type_and_peering_policy_if_invalid():
-    app = build_app()
-    processor = importers.process_asn_data(processing_date, TestLookup(), app)
+    app, _ = build_app()
+    processor = importers.process_asn_data(processing_date, MockLookup(), app)
     asn_data = PeeringASNFactory()
     asn_data["info_type"] = "foobar"
     asn_data["policy_general"] = "foobar"
@@ -71,7 +71,7 @@ def test_uses_defaults_for_network_type_and_peering_policy_if_invalid():
 def test_updates_existing_data(faker):
     name = faker.nic_handle(suffix="FAKE")
     updated_asn_data = PeeringASNFactory(name=(name + "new"))
-    app = build_app()
+    app, _ = build_app()
     app.import_asn(
         updated_asn_data["asn"],
         name,
@@ -84,7 +84,7 @@ def test_updates_existing_data(faker):
     )
 
     processor = importers.process_asn_data(
-        processing_date, TestLookup(default_country="AU"), app
+        processing_date, MockLookup(default_country="AU"), app
     )
     processor([updated_asn_data])
 
@@ -100,8 +100,8 @@ def test_handles_errors_with_source_data():
     data_with_problems["updated"] = "abc"
     data_with_problems["asn"] = "foobar"
 
-    app = build_app()
-    processor = importers.process_asn_data(processing_date, TestLookup(), app)
+    app, _ = build_app()
+    processor = importers.process_asn_data(processing_date, MockLookup(), app)
     processor([data_with_problems])
 
     asns = app.get_all_asns()
@@ -111,13 +111,13 @@ def test_handles_errors_with_source_data():
 def test_uses_registration_country_at_processing_date():
     updated_date = processing_date.replace(year=(processing_date.year - 1))
 
-    class DateSensitiveLookup(TestLookup):
+    class DateSensitiveLookup(MockLookup):
         def get_iso2_country(self, asn: int, as_at: datetime) -> str:
             if as_at.year == updated_date.year:
                 return "FR"
             return self.default_country
 
-    app = build_app()
+    app, _ = build_app()
     processor = importers.process_asn_data(processing_date, DateSensitiveLookup(), app)
     processor([PeeringASNFactory(updated_date=updated_date)])
 

--- a/tests/test_check_if_members_have_left.py
+++ b/tests/test_check_if_members_have_left.py
@@ -2,7 +2,7 @@ from datetime import timedelta, timezone, datetime
 
 from ixp_tracker.ixp_tracker import check_if_members_have_left
 from ixp_tracker.ixp_tracker_aggregates import IXPMemberDetails
-from tests.fixtures import TestLookup
+from tests.fixtures import MockLookup
 
 date_now = datetime.now(timezone.utc)
 
@@ -19,7 +19,7 @@ def test_marks_member_as_left_that_is_no_longer_active(faker):
         )
     }
 
-    members_left = check_if_members_have_left(members, date_now, TestLookup())
+    members_left = check_if_members_have_left(members, date_now, MockLookup())
 
     expected_end_date = last_day_of_last_month
     assert len(members_left) == 1
@@ -39,7 +39,7 @@ def test_marks_as112_as_left_if_no_longer_active(faker):
         )
     }
 
-    members_left = check_if_members_have_left(members, date_now, TestLookup())
+    members_left = check_if_members_have_left(members, date_now, MockLookup())
 
     expected_end_date = last_day_of_last_month
     assert len(members_left) == 1
@@ -56,7 +56,7 @@ def test_does_not_mark_member_as_left_if_asn_is_registered_in_country_zz_and_is_
     }
 
     members_left = check_if_members_have_left(
-        members, date_now, TestLookup(default_country="ZZ", default_status="assigned")
+        members, date_now, MockLookup(default_country="ZZ", default_status="assigned")
     )
 
     assert len(members_left) == 0
@@ -73,7 +73,7 @@ def test_does_not_mark_member_as_left_if_asn_is_registered_in_valid_country_and_
     members_left = check_if_members_have_left(
         members,
         date_now,
-        TestLookup(default_country=faker.country_code(), default_status="unassigned"),
+        MockLookup(default_country=faker.country_code(), default_status="unassigned"),
     )
 
     assert len(members_left) == 0
@@ -88,7 +88,7 @@ def test_marks_member_as_left_if_asn_is_registered_in_country_zz_and_is_not_assi
     }
 
     members_left = check_if_members_have_left(
-        members, date_now, TestLookup(default_country="ZZ", default_status="unassigned")
+        members, date_now, MockLookup(default_country="ZZ", default_status="unassigned")
     )
 
     assert len(members_left) == 1
@@ -103,7 +103,7 @@ def test_does_not_mark_as112_as_left_if_registered_in_country_zz_and_is_not_assi
     }
 
     members_left = check_if_members_have_left(
-        members, date_now, TestLookup(default_country="ZZ", default_status="unassigned")
+        members, date_now, MockLookup(default_country="ZZ", default_status="unassigned")
     )
 
     assert len(members_left) == 0
@@ -119,7 +119,7 @@ def test_does_not_mark_as_left_before_joining_date(faker):
         )
     }
 
-    members_left = check_if_members_have_left(members, date_now, TestLookup())
+    members_left = check_if_members_have_left(members, date_now, MockLookup())
 
     assert len(members_left) == 0
 

--- a/tests/test_country_stats_es.py
+++ b/tests/test_country_stats_es.py
@@ -3,13 +3,6 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from faker import Faker
 
-from ixp_tracker.ixp_tracker_projections import ASNList, IXPIdMapProjection
-
-from ixp_tracker.ixp_tracker_aggregates import IXP_TRACKER_EVENT_MAP
-
-from ixp_tracker.ixp_tracker import IXPTracker
-
-from ixp_tracker.event_store import EventStorePersistence, EventStore, DjangoEventStore
 
 from ixp_tracker.models import StatsPerCountryES
 from ixp_tracker.stats import do_generate_stats
@@ -21,6 +14,7 @@ from tests.fixtures import (
     create_asn,
     create_member,
     StatsPerCountryESFactory,
+    build_app,
 )
 
 pytestmark = pytest.mark.django_db
@@ -243,13 +237,3 @@ def test_updates_existing_stats_entry():
     assert country_stats.ixp_count == 0
     assert country_stats.routed_asn_count == 0
     assert country_stats.member_count == 0
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(ASNList())
-    es.add_listener(IXPIdMapProjection())
-    app = IXPTracker(es, MockLookup())
-    return app, es

--- a/tests/test_fetch_updated_ixps.py
+++ b/tests/test_fetch_updated_ixps.py
@@ -3,23 +3,13 @@ from statistics import median
 
 import pytest
 from faker import Faker
-from ixp_tracker.ixp_tracker_projections import (
-    ASNList,
-    IXPIdMapProjection,
-    IXPsLastUpdatedProjection,
-)
 
-from ixp_tracker.ixp_tracker_aggregates import IXP_TRACKER_EVENT_MAP
-
-from ixp_tracker.ixp_tracker import IXPTracker
-
-from ixp_tracker.event_store import EventStorePersistence, EventStore, DjangoEventStore
 
 from tests.fixtures import (
     create_ixp,
-    TestLookup,
     create_member,
     create_asn,
+    build_app,
 )
 
 pytestmark = pytest.mark.django_db
@@ -168,14 +158,3 @@ def test_with_offset_after_last_id_returns_nothing(faker: Faker):
     records = app.fetch_updated_ixp_records(None, first_id=(last_id + 1))
 
     assert len(records) == 0
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(IXPIdMapProjection())
-    es.add_listener(ASNList())
-    es.add_listener(IXPsLastUpdatedProjection())
-    app = IXPTracker(es, TestLookup())
-    return app, es

--- a/tests/test_ixp_stats_es.py
+++ b/tests/test_ixp_stats_es.py
@@ -3,17 +3,12 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from faker import Faker
 
-from ixp_tracker.ixp_tracker_projections import ASNList, IXPIdMapProjection
 
 from ixp_tracker.ixp_tracker_aggregates import (
-    IXP_TRACKER_EVENT_MAP,
     IXPMemberJoined,
     stringify_date,
 )
 
-from ixp_tracker.ixp_tracker import IXPTracker
-
-from ixp_tracker.event_store import EventStorePersistence, EventStore, DjangoEventStore
 
 from ixp_tracker.models import StatsPerIXPES
 from ixp_tracker.stats import do_generate_stats
@@ -25,6 +20,7 @@ from tests.fixtures import (
     create_asn,
     create_member,
     StatsPerIXPESFactory,
+    build_app,
 )
 
 pytestmark = pytest.mark.django_db
@@ -347,13 +343,3 @@ def test_updates_existing_stats(faker: Faker):
     ixp_stats = all_stats_for_ixp.first()
     assert ixp_stats.last_generated > existing.last_generated
     assert ixp_stats.members > existing.members
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(ASNList())
-    es.add_listener(IXPIdMapProjection())
-    app = IXPTracker(es, MockLookup())
-    return app, es

--- a/tests/test_ixps_import_es.py
+++ b/tests/test_ixps_import_es.py
@@ -10,14 +10,14 @@ IXP_TRACKER_ENABLE_EVENT_SOURCING = True
 
 
 def test_with_no_data_does_nothing():
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(datetime.now(timezone.utc), MockLookup(), app)([])
 
     assert len(app.get_all_ixps()) == 0
 
 
 def test_imports_a_new_ixp():
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(datetime.now(timezone.utc), MockLookup(), app)(
         [PeeringIXFactory()]
     )
@@ -29,7 +29,7 @@ def test_imports_a_new_ixp():
 def test_import_handles_missing_data():
     new_data = PeeringIXFactory()
     del new_data["fac_count"]
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(datetime.now(timezone.utc), MockLookup(), app)(
         [new_data]
     )
@@ -40,7 +40,7 @@ def test_import_handles_missing_data():
 
 def test_updates_an_existing_ixp(faker):
     new_data = PeeringIXFactory()
-    app = build_app()
+    app, _ = build_app()
     city = faker.city()
     name = f"{city} - IX"
     long_name = f"{city} Internet Exchange Point"
@@ -74,7 +74,7 @@ def test_updates_an_existing_ixp(faker):
 def test_does_not_import_an_ixp_from_a_non_iso_country():
     new_data = PeeringIXFactory()
     new_data["country"] = "XK"  # XK is Kosovo, but it's not an official ISO code
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(datetime.now(timezone.utc), MockLookup(), app)(
         [new_data]
     )
@@ -87,7 +87,7 @@ def test_handles_errors_with_source_data():
     data_with_problems = PeeringIXFactory()
     data_with_problems["created"] = "abc"
 
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(datetime.now(timezone.utc), MockLookup(), app)(
         [data_with_problems]
     )
@@ -99,7 +99,7 @@ def test_handles_errors_with_source_data():
 def test_saves_manrs_participant():
     new_data = PeeringIXFactory()
     manrs_participants = [new_data["id"]]
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(
         datetime.now(timezone.utc),
         MockLookup(manrs_participants=manrs_participants),
@@ -113,7 +113,7 @@ def test_saves_manrs_participant():
 def test_saves_anchor_host():
     new_data = PeeringIXFactory()
     anchor_hosts = [new_data["id"]]
-    app = build_app()
+    app, _ = build_app()
     importers.process_ixp_data(
         datetime.now(timezone.utc),
         MockLookup(anchor_hosts=anchor_hosts),

--- a/tests/test_members_import_es.py
+++ b/tests/test_members_import_es.py
@@ -3,18 +3,15 @@ from datetime import datetime, timezone
 import pytest
 
 from ixp_tracker import importers
-from ixp_tracker.event_store import EventStorePersistence, EventStore, DjangoEventStore
-from ixp_tracker.ixp_tracker import (
-    IXPTracker,
-)
-from ixp_tracker.ixp_tracker_aggregates import IXP_TRACKER_EVENT_MAP, IXP
-from ixp_tracker.ixp_tracker_projections import ASNList, IXPIdMapProjection
+from ixp_tracker.event_store import DjangoEventStore
+from ixp_tracker.ixp_tracker_aggregates import IXP
 from tests.fixtures import (
     PeeringNetIXLANFactory,
-    TestLookup,
+    MockLookup,
     create_ixp,
     create_asn,
     create_member,
+    build_app,
 )
 
 pytestmark = pytest.mark.django_db
@@ -34,7 +31,7 @@ def test_adds_new_members(faker):
         asn=asn_two.number, ix_id=ixp.peeringdb_id
     )
 
-    processor = importers.process_member_data(date_now, TestLookup(), app)
+    processor = importers.process_member_data(date_now, MockLookup(), app)
     processor([member_import_one, member_import_two])
 
     ixp = es.get_aggregate(ixp.id, IXP)
@@ -51,7 +48,7 @@ def test_does_nothing_if_no_asn_found(faker):
     member_import = PeeringNetIXLANFactory(ix_id=ixp.peeringdb_id)
     fixture_events = len(des.get_events())
 
-    processor = importers.process_member_data(date_now, TestLookup(), app)
+    processor = importers.process_member_data(date_now, MockLookup(), app)
     processor([member_import])
 
     assert len(des.get_events()) == fixture_events
@@ -65,7 +62,7 @@ def test_does_nothing_if_no_ixp_found(faker):
     fixture_events = len(des.get_events())
 
     app, _ = build_app()
-    processor = importers.process_member_data(date_now, TestLookup(), app)
+    processor = importers.process_member_data(date_now, MockLookup(), app)
     processor([member_import])
 
     assert len(des.get_events()) == fixture_events
@@ -81,7 +78,7 @@ def test_updates_member(faker):
     )
     last_active = ixp.get_members().get(asn.number).last_active
 
-    processor = importers.process_member_data(date_now, TestLookup(), app)
+    processor = importers.process_member_data(date_now, MockLookup(), app)
     processor([member_import])
 
     ixp = es.get_aggregate(ixp.id, IXP)
@@ -106,7 +103,7 @@ def test_marks_members_left_if_ixp_not_referenced_in_import(faker):
         )
     assert ixp.active_status is True
 
-    processor = importers.process_member_data(date_now, TestLookup(), app)
+    processor = importers.process_member_data(date_now, MockLookup(), app)
     processor([])
 
     ixp = es.get_aggregate(ixp.id, IXP)
@@ -115,13 +112,3 @@ def test_marks_members_left_if_ixp_not_referenced_in_import(faker):
     all_members = ixp.get_members(True)
     assert len(all_members) == 3
     assert ixp.active_status is False
-
-
-def build_app(
-    es_db: EventStorePersistence | None = None,
-) -> tuple[IXPTracker, EventStore]:
-    es = EventStore(IXP_TRACKER_EVENT_MAP, es_db or DjangoEventStore())
-    es.add_listener(IXPIdMapProjection())
-    es.add_listener(ASNList())
-    app = IXPTracker(es, TestLookup())
-    return app, es


### PR DESCRIPTION
Tidying up the tests. We had multiple `build_app` functions and two mocks for the additional data sources so I've combined each into one version.